### PR TITLE
Fix for Bug #75022: Sockets stay in CLOSE_WAIT when using SSL

### DIFF
--- a/Source/MySql.Data/NativeDriver.cs
+++ b/Source/MySql.Data/NativeDriver.cs
@@ -378,7 +378,7 @@ namespace MySql.Data.MySqlClient
     {
       RemoteCertificateValidationCallback sslValidateCallback =
           new RemoteCertificateValidationCallback(ServerCheckValidation);
-      SslStream ss = new SslStream(baseStream, true, sslValidateCallback, null);
+      SslStream ss = new SslStream(baseStream, false, sslValidateCallback, null);
       X509CertificateCollection certs = GetClientCertificates();
       ss.AuthenticateAsClient(Settings.Server, certs, SslProtocols.Tls, false);
       baseStream = ss;


### PR DESCRIPTION
Disconnect sockets when using the .NET Connector
http://bugs.mysql.com/bug.php?id=75022
