### PR TITLE
Update command.cs

### DIFF
--- a/Source/MySql.Data/command.cs
+++ b/Source/MySql.Data/command.cs
@@ -1,4 +1,4 @@
-// Copyright © 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+// Copyright Â© 2004, 2015, Oracle and/or its affiliates. All rights reserved.
 //
 // MySQL Connector/NET is licensed under the terms of the GPLv2
 // <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most 
@@ -284,7 +284,7 @@ namespace MySql.Data.MySqlClient
     /// </remarks>
     public override void Cancel()
     {
-      connection.CancelQuery(connection.ConnectionTimeout);
+      if (connection!=null) connection.CancelQuery(connection.ConnectionTimeout);
       canceled = true;
     }
 


### PR DESCRIPTION
Currently if MySqlCommand was asynchronously executed with a CancellationToken, and that token is cancelled After the command is disposed, the MySqlCommand.Cancel() throws NullReferenceException because at that point command's connection is null. This is OK for release builds because the exception would be caught by System.Data.Common.DbCommand's internal logic, but it is very annoying to see these exceptions when debugging. Additionally, it ads extra unnecessary overhead of throwing/catching an exception. The fix is simply to check whether connection is null before calling CancelQuery.