### PR TITLE
Remove the AllowPartiallyTrustedCallers attribute

### DIFF
--- a/EntityFramework6/src/Properties/AssemblyInfo.cs
+++ b/EntityFramework6/src/Properties/AssemblyInfo.cs
@@ -20,7 +20,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc., 
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-using System.Security;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -42,7 +41,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: AllowPartiallyTrustedCallers]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 // [assembly: Guid("540e7b3c-bd0b-4980-96d1-5d140d303f7e")]
 


### PR DESCRIPTION
The AllowPartiallyTrustedCallers attribute is causing this exception, rendering MySql.Data.Entity for EF6 totally unusable:
System.InvalidOperationException: The DbConfiguration type 'MySql.Data.Entity.MySqlEFConfiguration, MySql.Data.Entity.EF6' specified in the application config file could not be loaded. Make sure that the assembly-qualified name is used and that the assembly is available to the running application. See http://go.microsoft.com/fwlink/?LinkId=260883 for more information. ---> System.TypeLoadException: Inheritance security rules violated by type: 'MySql.Data.Entity.MySqlEFConfiguration'. Derived types must either match the security accessibility of the base type or be less accessible.

Fixes #12