### PR TITLE
Regression of Bug #83973

### DIFF
--- a/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLDatabaseCreator.cs
+++ b/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLDatabaseCreator.cs
@@ -142,7 +142,7 @@ namespace MySql.Data.EntityFrameworkCore
 
     protected override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
     {
-      string sql = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = `" + _connection.DbConnection.Database + "`";
+      string sql = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '" + _connection.DbConnection.Database + "'";
       long count = (long)await _rawSqlCommandBuilder.Build(sql).ExecuteScalarAsync(_connection, cancellationToken: cancellationToken);
       return count != 0;
     }


### PR DESCRIPTION
HasTablesAsync (used by context.Database.EnsureCreatedAsync) has incorrect quotes for the database name string.
This fix applies the same resolution as https://github.com/mysql/mysql-connector-net/pull/5