### PR TITLE
Fix generating sql literal for byte array.

### DIFF
--- a/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLBinaryTypeMapping.cs
+++ b/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLBinaryTypeMapping.cs
@@ -49,5 +49,16 @@ namespace MySql.Data.EntityFrameworkCore.Storage.Internal
 
     public override RelationalTypeMapping Clone([NotNull] string storeType, int? size)
       => new MySQLBinaryTypeMapping(storeType, DbType);
+
+    protected override string GenerateNonNullSqlLiteral([NotNull] object value)
+    {
+      byte[] ba = value as byte[];
+      StringBuilder unhex = new StringBuilder(ba.Length * 2);
+      unhex.Append("unhex('");
+      foreach (byte b in ba)
+        unhex.AppendFormat("{0:x2}", b);
+      unhex.Append("')");
+      return unhex.ToString();
+    }
   }
 }

--- a/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLBinaryTypeMapping.cs
+++ b/EFCore/src/MySql.Data.EFCore/Storage/Internal/MySQLBinaryTypeMapping.cs
@@ -33,6 +33,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using MySql.Data.EntityFrameworkCore;
 using System.Data;
+using System.Text;
 
 namespace MySql.Data.EntityFrameworkCore.Storage.Internal
 {


### PR DESCRIPTION
Fix generating sql literal for byte array.

Related bug: https://bugs.mysql.com/bug.php?id=93398