### PR TITLE
Missing InvariantCulture on Parse methods

### DIFF
--- a/EntityFramework/src/ProviderServices.cs
+++ b/EntityFramework/src/ProviderServices.cs
@@ -56,7 +56,7 @@ namespace MySql.Data.MySqlClient
 				using (var conn = new MySqlConnection(connectionString.Replace(@"""", "")))
 				{
 					conn.Open();                  
-					var v = DBVersion.Parse(conn.ServerVersion.ToString());        
+					var v = DBVersion.Parse(conn.ServerVersion.ToString());
 					service.serverVersion = new Version(v.Major + "." + v.Minor);
 				}
 			}

--- a/MySQL.Data/src/Driver.cs
+++ b/MySQL.Data/src/Driver.cs
@@ -321,7 +321,7 @@ namespace MySql.Data.MySqlClient
       if (timeZoneDiff.HasValue)
         timeZoneString = timeZoneDiff.ToString();
 
-      return int.Parse(timeZoneString.Substring(0, timeZoneString.IndexOf(':')));
+      return int.Parse(timeZoneString.Substring(0, timeZoneString.IndexOf(':')), CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/MySQL.Data/src/ISSchemaProvider.cs
+++ b/MySQL.Data/src/ISSchemaProvider.cs
@@ -717,14 +717,14 @@ namespace MySql.Data.MySqlClient
 
       if (!MetaData.IsNumericType(row["DATA_TYPE"].ToString()))
       {
-        row["CHARACTER_MAXIMUM_LENGTH"] = Int32.Parse(parts[0]);
+        row["CHARACTER_MAXIMUM_LENGTH"] = Int32.Parse(parts[0], CultureInfo.InvariantCulture);
         // will set octet length in a minute
       }
       else
       {
-        row["NUMERIC_PRECISION"] = Int32.Parse(parts[0]);
+        row["NUMERIC_PRECISION"] = Int32.Parse(parts[0], CultureInfo.InvariantCulture);
         if (parts.Length == 2)
-          row["NUMERIC_SCALE"] = Int32.Parse(parts[1]);
+          row["NUMERIC_SCALE"] = Int32.Parse(parts[1], CultureInfo.InvariantCulture);
       }
     }
 

--- a/MySQL.Data/src/MySqlBaseConnectionStringBuilder.cs
+++ b/MySQL.Data/src/MySqlBaseConnectionStringBuilder.cs
@@ -637,16 +637,16 @@ namespace MySql.Data.MySqlClient
       if (typeName == "Boolean" && Boolean.TryParse(value.ToString(), out b)) { value = b; return; }
 
       UInt64 uintVal;
-      if (typeName.StartsWith("UInt64") && UInt64.TryParse(value.ToString(), out uintVal)) { value = uintVal; return; }
+      if (typeName.StartsWith("UInt64") && UInt64.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out uintVal)) { value = uintVal; return; }
 
       UInt32 uintVal32;
-      if (typeName.StartsWith("UInt32") && UInt32.TryParse(value.ToString(), out uintVal32)) { value = uintVal32; return; }
+      if (typeName.StartsWith("UInt32") && UInt32.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out uintVal32)) { value = uintVal32; return; }
 
       Int64 intVal;
-      if (typeName.StartsWith("Int64") && Int64.TryParse(value.ToString(), out intVal)) { value = intVal; return; }
+      if (typeName.StartsWith("Int64") && Int64.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out intVal)) { value = intVal; return; }
 
       Int32 intVal32;
-      if (typeName.StartsWith("Int32") && Int32.TryParse(value.ToString(), out intVal32)) { value = intVal32; return; }
+      if (typeName.StartsWith("Int32") && Int32.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out intVal32)) { value = intVal32; return; }
 
       object objValue;
       Type baseType = BaseType.GetTypeInfo().BaseType;
@@ -666,7 +666,7 @@ namespace MySql.Data.MySqlClient
       switch (keyword)
       {
         case "connect-timeout":
-          if (typeName != valueType.Name  && !uint.TryParse(value.ToString(), out uint uintVal)) throw new FormatException(ResourcesX.InvalidConnectionTimeoutValue);
+          if (typeName != valueType.Name  && !uint.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out uint uintVal)) throw new FormatException(ResourcesX.InvalidConnectionTimeoutValue);
           break;
       }
     }

--- a/MySQL.Data/src/MysqlDefs.cs
+++ b/MySQL.Data/src/MysqlDefs.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
 
 namespace MySql.Data.MySqlClient
@@ -530,7 +531,7 @@ namespace MySql.Data.MySqlClient
         string pid = string.Empty;
         try
         {
-          pid = System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
+          pid = System.Diagnostics.Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
         }
         catch (Exception ex)
         {
@@ -561,7 +562,7 @@ namespace MySql.Data.MySqlClient
         string thread = string.Empty;
         try
         {
-          thread = System.Diagnostics.Process.GetCurrentProcess().Threads[0].Id.ToString();
+          thread = System.Diagnostics.Process.GetCurrentProcess().Threads[0].Id.ToString(CultureInfo.InvariantCulture);
         }
         catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex.ToString()); }
 

--- a/MySQL.Data/src/SchemaProvider.cs
+++ b/MySQL.Data/src/SchemaProvider.cs
@@ -67,7 +67,7 @@ namespace MySql.Data.MySqlClient
     public virtual MySqlSchemaCollection GetDatabases(string[] restrictions)
     {
       Regex regex = null;
-      int caseSetting = Int32.Parse(connection.driver.Property("lower_case_table_names"));
+      int caseSetting = Int32.Parse(connection.driver.Property("lower_case_table_names"), CultureInfo.InvariantCulture);
 
       string sql = "SHOW DATABASES";
 

--- a/MySQL.Data/src/Types/MySqlBit.cs
+++ b/MySQL.Data/src/Types/MySqlBit.cs
@@ -64,7 +64,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteInteger((long)v, 8);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     public IMySqlValue ReadValue(MySqlPacket packet, long length, bool isNull)
@@ -99,7 +99,7 @@ namespace MySql.Data.Types
       row["ProviderDbType"] = MySqlDbType.Bit;
       row["ColumnSize"] = 64;
       row["CreateFormat"] = "BIT";
-      row["CreateParameters"] = DBNull.Value; ;
+      row["CreateParameters"] = DBNull.Value;
       row["DataType"] = typeof(ulong).ToString();
       row["IsAutoincrementable"] = false;
       row["IsBestMatch"] = true;

--- a/MySQL.Data/src/Types/MySqlBit.cs
+++ b/MySQL.Data/src/Types/MySqlBit.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -76,7 +77,7 @@ namespace MySql.Data.Types
         length = packet.ReadFieldLength();
 
       if (ReadAsString)
-        _value = UInt64.Parse(packet.ReadString(length));
+        _value = UInt64.Parse(packet.ReadString(length), CultureInfo.InvariantCulture);
       else
         _value = (UInt64)packet.ReadBitValue((int)length);
       return this;

--- a/MySQL.Data/src/Types/MySqlByte.cs
+++ b/MySQL.Data/src/Types/MySqlByte.cs
@@ -76,7 +76,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteByte((byte)v);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlDateTime.cs
+++ b/MySQL.Data/src/Types/MySqlDateTime.cs
@@ -309,21 +309,21 @@ namespace MySql.Data.Types
     {
       string[] parts = s.Split('-', ' ', ':', '/', '.');
 
-      int year = int.Parse(parts[0]);
-      int month = int.Parse(parts[1]);
-      int day = int.Parse(parts[2]);
+      int year = int.Parse(parts[0], CultureInfo.InvariantCulture);
+      int month = int.Parse(parts[1], CultureInfo.InvariantCulture);
+      int day = int.Parse(parts[2], CultureInfo.InvariantCulture);
 
       int hour = 0, minute = 0, second = 0, microsecond = 0;
       if (parts.Length > 3)
       {
-        hour = int.Parse(parts[3]);
-        minute = int.Parse(parts[4]);
-        second = int.Parse(parts[5]);
+        hour = int.Parse(parts[3], CultureInfo.InvariantCulture);
+        minute = int.Parse(parts[4], CultureInfo.InvariantCulture);
+        second = int.Parse(parts[5], CultureInfo.InvariantCulture);
       }
 
       if (parts.Length > 6)
       {
-        microsecond = int.Parse(parts[6].PadRight(6, '0'));
+        microsecond = int.Parse(parts[6].PadRight(6, '0'), CultureInfo.InvariantCulture);
       }
 
       return new MySqlDateTime(_type, year, month, day, hour, minute, second, microsecond);

--- a/MySQL.Data/src/Types/MySqlDateTime.cs
+++ b/MySQL.Data/src/Types/MySqlDateTime.cs
@@ -415,7 +415,7 @@ namespace MySql.Data.Types
       if (this.IsValidDateTime)
       {
         DateTime d = new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(_microsecond * 10);
-        return (_type == MySqlDbType.Date) ? d.ToString("d") : d.ToString();
+        return (_type == MySqlDbType.Date) ? d.ToString("d", CultureInfo.InvariantCulture) : d.ToString(CultureInfo.InvariantCulture);
       }
 
       string dateString = FormatDateCustom(

--- a/MySQL.Data/src/Types/MySqlDecimal.cs
+++ b/MySQL.Data/src/Types/MySqlDecimal.cs
@@ -86,7 +86,7 @@ namespace MySql.Data.Types
     /// <returns>The value of this type converted to a dobule value.</returns>
     public double ToDouble()
     {
-      return Double.Parse(_value);
+      return Double.Parse(_value, CultureInfo.InvariantCulture);
     }
 
     public override string ToString()

--- a/MySQL.Data/src/Types/MySqlInt16.cs
+++ b/MySQL.Data/src/Types/MySqlInt16.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -76,7 +77,7 @@ namespace MySql.Data.Types
       if (length == -1)
         return new MySqlInt16((short)packet.ReadInteger(2));
       else
-        return new MySqlInt16(Int16.Parse(packet.ReadString(length)));
+        return new MySqlInt16(Int16.Parse(packet.ReadString(length), CultureInfo.InvariantCulture));
     }
 
     void IMySqlValue.SkipValue(MySqlPacket packet)

--- a/MySQL.Data/src/Types/MySqlInt16.cs
+++ b/MySQL.Data/src/Types/MySqlInt16.cs
@@ -66,7 +66,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteInteger((long)v, 2);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlInt32.cs
+++ b/MySQL.Data/src/Types/MySqlInt32.cs
@@ -75,9 +75,9 @@ namespace MySql.Data.Types
     {
       int v = val as int? ?? Convert.ToInt32(val);
       if (binary)
-        packet.WriteInteger((long)v, _is24Bit ? 3 : 4);
+        packet.WriteInteger(v, _is24Bit ? 3 : 4);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlInt64.cs
+++ b/MySQL.Data/src/Types/MySqlInt64.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -79,7 +80,7 @@ namespace MySql.Data.Types
       if (length == -1)
         return new MySqlInt64((long)packet.ReadULong(8));
       else
-        return new MySqlInt64(Int64.Parse(packet.ReadString(length)));
+        return new MySqlInt64(Int64.Parse(packet.ReadString(length), CultureInfo.InvariantCulture));
     }
 
     void IMySqlValue.SkipValue(MySqlPacket packet)

--- a/MySQL.Data/src/Types/MySqlInt64.cs
+++ b/MySQL.Data/src/Types/MySqlInt64.cs
@@ -69,7 +69,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteInteger(v, 8);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlSingle.cs
+++ b/MySQL.Data/src/Types/MySqlSingle.cs
@@ -69,8 +69,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.Write(BitConverter.GetBytes(v));
       else
-        packet.WriteStringNoNull(v.ToString("R",
-   CultureInfo.InvariantCulture));
+        packet.WriteStringNoNull(v.ToString("R", CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlTime.cs
+++ b/MySQL.Data/src/Types/MySqlTime.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -177,16 +178,16 @@ namespace MySql.Data.Types
     {
 
       string[] parts = s.Split(':', '.');
-      int hours = Int32.Parse(parts[0]);
-      int mins = Int32.Parse(parts[1]);
-      int secs = Int32.Parse(parts[2]);
+      int hours = Int32.Parse(parts[0], CultureInfo.InvariantCulture);
+      int mins = Int32.Parse(parts[1], CultureInfo.InvariantCulture);
+      int secs = Int32.Parse(parts[2], CultureInfo.InvariantCulture);
       int nanoseconds = 0;
 
       if (parts.Length > 3)
       {
         //if the data is saved in MySql as Time(3) the division by 1000 always returns 0, but handling the data as Time(6) the result is the expected
         parts[3] = parts[3].PadRight(7, '0');
-        nanoseconds = int.Parse(parts[3]);
+        nanoseconds = int.Parse(parts[3], CultureInfo.InvariantCulture);
       }
 
 

--- a/MySQL.Data/src/Types/MySqlUByte.cs
+++ b/MySQL.Data/src/Types/MySqlUByte.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -76,7 +77,7 @@ namespace MySql.Data.Types
       if (length == -1)
         return new MySqlUByte((byte)packet.ReadByte());
       else
-        return new MySqlUByte(Byte.Parse(packet.ReadString(length)));
+        return new MySqlUByte(Byte.Parse(packet.ReadString(length), CultureInfo.InvariantCulture));
     }
 
     void IMySqlValue.SkipValue(MySqlPacket packet)

--- a/MySQL.Data/src/Types/MySqlUByte.cs
+++ b/MySQL.Data/src/Types/MySqlUByte.cs
@@ -66,7 +66,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteByte(v);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlUInt16.cs
+++ b/MySQL.Data/src/Types/MySqlUInt16.cs
@@ -64,9 +64,9 @@ namespace MySql.Data.Types
     {
       int v = (val is UInt16) ? (UInt16)val : Convert.ToUInt16(val);
       if (binary)
-        packet.WriteInteger((long)v, 2);
+        packet.WriteInteger(v, 2);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlUInt16.cs
+++ b/MySQL.Data/src/Types/MySqlUInt16.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -76,7 +77,7 @@ namespace MySql.Data.Types
       if (length == -1)
         return new MySqlUInt16((ushort)packet.ReadInteger(2));
       else
-        return new MySqlUInt16(UInt16.Parse(packet.ReadString(length)));
+        return new MySqlUInt16(UInt16.Parse(packet.ReadString(length), CultureInfo.InvariantCulture));
     }
 
     void IMySqlValue.SkipValue(MySqlPacket packet)

--- a/MySQL.Data/src/Types/MySqlUInt32.cs
+++ b/MySQL.Data/src/Types/MySqlUInt32.cs
@@ -79,7 +79,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteInteger((long)val, _is24Bit ? 3 : 4);
       else
-        packet.WriteStringNoNull(val.ToString());
+        packet.WriteStringNoNull(val.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/Types/MySqlUInt64.cs
+++ b/MySQL.Data/src/Types/MySqlUInt64.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Types
@@ -79,7 +80,7 @@ namespace MySql.Data.Types
       if (length == -1)
         return new MySqlUInt64(packet.ReadULong(8));
       else
-        return new MySqlUInt64(UInt64.Parse(packet.ReadString(length)));
+        return new MySqlUInt64(UInt64.Parse(packet.ReadString(length), CultureInfo.InvariantCulture));
     }
 
     void IMySqlValue.SkipValue(MySqlPacket packet)

--- a/MySQL.Data/src/Types/MySqlUInt64.cs
+++ b/MySQL.Data/src/Types/MySqlUInt64.cs
@@ -69,7 +69,7 @@ namespace MySql.Data.Types
       if (binary)
         packet.WriteInteger((long)v, 8);
       else
-        packet.WriteStringNoNull(v.ToString());
+        packet.WriteStringNoNull(v.ToString(CultureInfo.InvariantCulture));
     }
 
     IMySqlValue IMySqlValue.ReadValue(MySqlPacket packet, long length, bool nullVal)

--- a/MySQL.Data/src/X/Protocol/X/DecimalDecoder.cs
+++ b/MySQL.Data/src/X/Protocol/X/DecimalDecoder.cs
@@ -31,6 +31,7 @@ using MySql.Data;
 using MySql.Data.MySqlClient.X.XDevAPI.Common;
 using MySqlX.Data;
 using System;
+using System.Globalization;
 
 namespace MySqlX.Protocol.X
 {
@@ -75,7 +76,7 @@ namespace MySqlX.Protocol.X
       stringValue += lastDigit;
       stringValue = stringValue.Insert(stringValue.Length - scale, ".");
 
-      return Decimal.Parse(stringValue);
+      return Decimal.Parse(stringValue, CultureInfo.InvariantCulture);
     }
   }
 }

--- a/MySQL.Data/src/X/Protocol/X/ExprParser.cs
+++ b/MySQL.Data/src/X/Protocol/X/ExprParser.cs
@@ -30,6 +30,7 @@ using Mysqlx.Crud;
 using Mysqlx.Expr;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -676,7 +677,7 @@ namespace MySqlX.Protocol.X
       }
       else if (CurrentTokenTypeEquals(TokenType.LNUM_INT))
       {
-        uint v = uint.Parse(this.tokens[this.tokenPos].value);
+        uint v = uint.Parse(this.tokens[this.tokenPos].value, CultureInfo.InvariantCulture);
         if (v < 0)
         {
           throw new ArgumentException("Array index cannot be negative at " + this.tokenPos);
@@ -966,9 +967,9 @@ namespace MySqlX.Protocol.X
         case TokenType.NULL:
           return ExprUtil.BuildLiteralNullScalar();
         case TokenType.LNUM_INT:
-          return ExprUtil.BuildLiteralScalar(long.Parse(t.value));
+          return ExprUtil.BuildLiteralScalar(long.Parse(t.value, CultureInfo.InvariantCulture));
         case TokenType.LNUM_DOUBLE:
-          return ExprUtil.BuildLiteralScalar(double.Parse(t.value));
+          return ExprUtil.BuildLiteralScalar(double.Parse(t.value, CultureInfo.InvariantCulture));
         case TokenType.TRUE:
         case TokenType.FALSE:
           return ExprUtil.BuildLiteralScalar(t.type == TokenType.TRUE);

--- a/MySql.Web/src/PersonalizationProviderProcedures.cs
+++ b/MySql.Web/src/PersonalizationProviderProcedures.cs
@@ -27,6 +27,7 @@
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 using System;
+using System.Globalization;
 using MySql.Data.MySqlClient;
 
 namespace MySql.Web.Personalization
@@ -167,7 +168,7 @@ namespace MySql.Web.Personalization
         findStateCommand.Parameters.AddWithValue("@PageLowerBound", pageLowerBound);
         findStateCommand.Connection = connection.Connection;
 
-        return int.Parse(totalRecords);
+        return int.Parse(totalRecords, CultureInfo.InvariantCulture);
       }
     }
 
@@ -192,7 +193,7 @@ namespace MySql.Web.Personalization
         cmd.Parameters.AddWithValue("@Path", path);
         cmd.Connection = connection.Connection;
         var count = cmd.ExecuteScalar().ToString();
-        return int.Parse(count);
+        return int.Parse(count, CultureInfo.InvariantCulture);
       }
       else {
         MySqlCommand cmd = new MySqlCommand("Select count(*) from my_aspnet_personalizationperuser as peruser, my_aspnet_users as users, "+
@@ -210,7 +211,7 @@ namespace MySql.Web.Personalization
         cmd.Parameters.AddWithValue("@InactiveSinceDate", inactiveSinceDate);
         cmd.Connection = connection.Connection;
         var count = cmd.ExecuteScalar().ToString();
-        return int.Parse(count);
+        return int.Parse(count, CultureInfo.InvariantCulture);
       }    
     }
 
@@ -244,10 +245,10 @@ namespace MySql.Web.Personalization
       var userId = (cmd.ExecuteScalar() ?? "").ToString();
       userId = string.IsNullOrEmpty(userId) ? "0" : userId;
 
-      if (int.Parse(userId) == 0)
+      if (int.Parse(userId, CultureInfo.InvariantCulture) == 0)
         return null;
 
-      UpdateUserLastActiveDate(connection.Connection, int.Parse(userId), currentTimeUtc);      
+      UpdateUserLastActiveDate(connection.Connection, int.Parse(userId, CultureInfo.InvariantCulture), currentTimeUtc);      
 
       cmd = new MySqlCommand("select pagesettings from my_aspnet_personalizationperuser as peruser where peruser.pathid = @PathId and peruser.userid = @UserId");
       cmd.Connection = connection.Connection;
@@ -576,7 +577,7 @@ namespace MySql.Web.Personalization
       userId = string.IsNullOrEmpty(userId) ? "0" : userId;
 
       // create user
-      if (int.Parse(userId) == 0)
+      if (int.Parse(userId, CultureInfo.InvariantCulture) == 0)
       {
         // create path        
         MySqlTransaction trans;
@@ -606,7 +607,7 @@ namespace MySql.Web.Personalization
           userId = (string)cmd.ExecuteScalar();
    
       }
-      var rows = UpdateUserLastActiveDate(connection.Connection, int.Parse(userId), DateTime.UtcNow);
+      var rows = UpdateUserLastActiveDate(connection.Connection, int.Parse(userId, CultureInfo.InvariantCulture), DateTime.UtcNow);
       if (rows == 0)
         throw new Exception("User not found");
 

--- a/MySql.Web/src/SimpleMembershipProvider.cs
+++ b/MySql.Web/src/SimpleMembershipProvider.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Configuration.Provider;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -111,10 +112,10 @@ namespace MySql.Web.Security
       base.Initialize(name, config);
 
       var appName = GetConfigValue(config["applicationName"], HostingEnvironment.SiteName);
-      _maxPwdAttempts = Int32.Parse(GetConfigValue(config["maxInvalidPasswordAttempts"], "5"));
-      _pwdAttemptWindow = Int32.Parse(GetConfigValue(config["passwordAttemptWindow"], "10"));
-      _minReqNonAlphanumericalChars = Int32.Parse(GetConfigValue(config["minRequiredNonalphanumericCharacters"], "1"));
-      _minReqPwdLength = Int32.Parse(GetConfigValue(config["minRequiredPasswordLength"], "7"));
+      _maxPwdAttempts = Int32.Parse(GetConfigValue(config["maxInvalidPasswordAttempts"], "5"), CultureInfo.InvariantCulture);
+      _pwdAttemptWindow = Int32.Parse(GetConfigValue(config["passwordAttemptWindow"], "10"), CultureInfo.InvariantCulture);
+      _minReqNonAlphanumericalChars = Int32.Parse(GetConfigValue(config["minRequiredNonalphanumericCharacters"], "1"), CultureInfo.InvariantCulture);
+      _minReqPwdLength = Int32.Parse(GetConfigValue(config["minRequiredPasswordLength"], "7"), CultureInfo.InvariantCulture);
       _pwdStrenghtRegex = GetConfigValue(config["passwordStrengthRegularExpression"], "");
       _enablePwdReset = bool.Parse(GetConfigValue(config["enablePasswordReset"], "True"));
       _enablePwdRetrival = bool.Parse(GetConfigValue(config["enablePasswordRetrieval"], "False"));

--- a/MySql.Web/src/SimpleRoleProvider.cs
+++ b/MySql.Web/src/SimpleRoleProvider.cs
@@ -32,6 +32,7 @@ using MySql.Web.Properties;
 using System;
 using System.Collections.Generic;
 using System.Configuration.Provider;
+using System.Globalization;
 using System.Linq;
 using System.Resources;
 using System.Web.Hosting;
@@ -104,10 +105,10 @@ namespace MySql.Web.Security
       base.Initialize(name, config);
 
       var appName = GetConfigValue(config["applicationName"], HostingEnvironment.SiteName);
-      _maxPwdAttempts = Int32.Parse(GetConfigValue(config["maxInvalidPasswordAttempts"], "5"));
-      _pwdAttemptWindow = Int32.Parse(GetConfigValue(config["passwordAttemptWindow"], "10"));
-      _minReqNonAlphanumericalChars = Int32.Parse(GetConfigValue(config["minRequiredNonalphanumericCharacters"], "1"));
-      _minReqPwdLength = Int32.Parse(GetConfigValue(config["minRequiredPasswordLength"], "7"));
+      _maxPwdAttempts = Int32.Parse(GetConfigValue(config["maxInvalidPasswordAttempts"], "5"), CultureInfo.InvariantCulture);
+      _pwdAttemptWindow = Int32.Parse(GetConfigValue(config["passwordAttemptWindow"], "10"), CultureInfo.InvariantCulture);
+      _minReqNonAlphanumericalChars = Int32.Parse(GetConfigValue(config["minRequiredNonalphanumericCharacters"], "1"), CultureInfo.InvariantCulture);
+      _minReqPwdLength = Int32.Parse(GetConfigValue(config["minRequiredPasswordLength"], "7"), CultureInfo.InvariantCulture);
       _pwdStrenghtRegex = GetConfigValue(config["passwordStrengthRegularExpression"], "");
       _enablePwdReset = bool.Parse(GetConfigValue(config["enablePasswordReset"], "True"));
       _enablePwdRetrival = bool.Parse(GetConfigValue(config["enablePasswordRetrieval"], "False"));


### PR DESCRIPTION
Hi,
The InvariantCulture is critical when parsing values (which MySql Connector does internally), as the Culture depends on the OS (or on the ICU package when using .NET Core on Linux).
I've noticed the fixed had already been applied to Int32, but not for all DataTypes.

Hope this could be merged quickly.

Thanks,
Effy