### PR TITLE
Update MySqlMigrationSqlGenerator.cs

### DIFF
--- a/EntityFramework/src/MySqlMigrationSqlGenerator.cs
+++ b/EntityFramework/src/MySqlMigrationSqlGenerator.cs
@@ -766,7 +766,7 @@ namespace MySql.Data.EntityFramework
       sb.Append("using " + indexType);
 
       // As of MySQL 8.0, ASC and DESC are not permitted for HASH indexes.
-      if (Convert.ToDouble(_providerManifestToken) >= 8.0 && indexType == "HASH")
+      if (Convert.ToDouble(_providerManifestToken, System.Globalization.CultureInfo.InvariantCulture) >= 8.0 && indexType == "HASH")
         sb.Replace(sortOrder, string.Empty);
 
       return new MigrationStatement() { Sql = sb.ToString() };


### PR DESCRIPTION
fix "Input string was not in a correct format" error in apply Migration on system which are not belongs to en-US region.