### PR TITLE
Bug #102937 Cast CreateHasTablesCommand result to Int64

### DIFF
--- a/EFCore5/src/Storage/Internal/MySQLDatabaseCreator.cs
+++ b/EFCore5/src/Storage/Internal/MySQLDatabaseCreator.cs
@@ -265,7 +265,7 @@ namespace MySql.EntityFrameworkCore
     public override Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
       => Dependencies.ExecutionStrategyFactory.Create().ExecuteAsync(
         _connection,
-        async (connection, ct) => (int)await CreateHasTablesCommand()
+        async (connection, ct) => (Int64)await CreateHasTablesCommand()
         .ExecuteScalarAsync(
           new RelationalCommandParameterObject(
             connection,


### PR DESCRIPTION
Small change to EFCore5 so it can complete schema checks when user uses EnsureCreatedAsync