### PR TITLE
Fix non-identification of utf8mb3 character set presented by (e.g) MariaDB 10.6

### DIFF
--- a/MySQL.Data/src/CharSetMap.cs
+++ b/MySQL.Data/src/CharSetMap.cs
@@ -155,6 +155,7 @@ namespace MySql.Data.MySqlClient
       _mapping.Add("latvian1", new CharacterSet("iso-8859-13", 1));
       _mapping.Add("estonia", new CharacterSet("iso-8859-13", 1));
       _mapping.Add("dos", new CharacterSet("ibm437", 1));
+      _mapping.Add("utf8mb3", new CharacterSet("utf-8", 3));
       _mapping.Add("utf8mb4", new CharacterSet("utf-8", 4));
       _mapping.Add("utf16", new CharacterSet("utf-16BE", 2));
       _mapping.Add("utf16le", new CharacterSet("utf-16", 2));


### PR DESCRIPTION
MariaDB 10.6 has changed the character set it advertises from "utf8" to "utf8mb3"

While fully supported, this is reported as unsupported by the connector

This change flags utf8mb3 as a supported charset