### PR TITLE
Run inserts in batch command as one block

### DIFF
--- a/MySQL.Data/src/Statement.cs
+++ b/MySQL.Data/src/Statement.cs
@@ -178,7 +178,7 @@ namespace MySql.Data.MySqlClient
           //long originalLength = packet.Length - 4;
 
           // and attempt to stream the next command
-          string text = ResolvedCommandText;
+          string text = batchedCmd.BatchableCommandText;
           if (text.StartsWith("(", StringComparison.Ordinal))
             packet.WriteStringNoNull(", ");
           else


### PR DESCRIPTION
A batch update did not run one insert statement per batch but multiple insert statements. The correct insert statements are already built but were not used.
Fixes #71832.