### PR TITLE
Permit connection to MariaDB 10.10

### DIFF
--- a/MySQL.Data/src/Driver.cs
+++ b/MySQL.Data/src/Driver.cs
@@ -344,7 +344,7 @@ namespace MySql.Data.MySqlClient
     private async Task LoadCharacterSetsAsync(MySqlConnection connection, bool execAsync, CancellationToken cancellationToken)
     {
       serverProps.TryGetValue("autocommit", out var serverAutocommit);
-      MySqlCommand cmd = new MySqlCommand("SHOW COLLATION", connection);
+      MySqlCommand cmd = new MySqlCommand("SHOW COLLATION WHERE ID IS NOT NULL", connection);
 
       // now we load all the currently active collations
       try


### PR DESCRIPTION
Driver cannot even connect to MariaDB 10.10+, connection fails with error :

```
[InvalidCastException: Object cannot be cast from DBNull to other types.]
System.DBNull.System.IConvertible.ToInt32(IFormatProvider provider) +57
MySql.Data.MySqlClient.Driver.LoadCharacterSets(MySqlConnection connection) +557
MySql.Data.MySqlClient.Driver.Configure(MySqlConnection connection) +200
MySql.Data.MySqlClient.MySqlConnection.Open() +1341
```

the reason is MariaDB 10.10 supports Unicode 14 with Collations that can have null id/null characters:

```sql
show collation where COLLATION like 'uca14%';
+--------------------------------+---------+------+---------+----------+---------+
| Collation                      | Charset | Id   | Default | Compiled | Sortlen |
+--------------------------------+---------+------+---------+----------+---------+
| uca1400_ai_ci                  | NULL    | NULL | NULL    | Yes      |       8 |
| uca1400_ai_cs                  | NULL    | NULL | NULL    | Yes      |       8 |
| uca1400_as_ci                  | NULL    | NULL | NULL    | Yes      |       8 |
| uca1400_as_cs                  | NULL    | NULL | NULL    | Yes      |       8 |
...
```

Since 10.10, some collation have null id in `I_S.COLLATIONS`/`SHOW COLLATIONS`. 
ID's only appear in I_S.COLLATION_CHARACTER_SET_APPLICABILITY, associate to charset.
example:
```sql
 SELECT * FROM INFORMATION_SCHEMA.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME LIKE 'uca1400_ai_ci';
 +----------------+--------------------+-----------------------+------+------------+
 | COLLATION_NAME | CHARACTER_SET_NAME | FULL_COLLATION_NAME   | ID   | IS_DEFAULT |
 +----------------+--------------------+-----------------------+------+------------+
 | uca1400_ai_ci  | utf8mb3            | utf8mb3_uca1400_ai_ci | 2048 |            |
 | uca1400_ai_ci  | ucs2               | ucs2_uca1400_ai_ci    | 2560 |            |
 | uca1400_ai_ci  | utf8mb4            | utf8mb4_uca1400_ai_ci | 2304 |            |
 | uca1400_ai_ci  | utf16              | utf16_uca1400_ai_ci   | 2816 |            |
 | uca1400_ai_ci  | utf32              | utf32_uca1400_ai_ci   | 3072 |            |
 +----------------+--------------------+-----------------------+------+------------+
 ```

This simple fix correct this connection problem 