### PR TITLE
bugfix schema name (specially usefull when use multiple schema in one…

### DIFF
--- a/EFCore5/src/Storage/Internal/MySQLSqlGenerationHelper.cs
+++ b/EFCore5/src/Storage/Internal/MySQLSqlGenerationHelper.cs
@@ -92,6 +92,6 @@ namespace MySql.EntityFrameworkCore
     => !string.IsNullOrEmpty(schema) &&  _options.SchemaNameTranslator != null
         ? _options.SchemaNameTranslator(schema, name)
         : name;
-    protected virtual string GetSchemaName(string name, string schema) => null;
+    protected virtual string GetSchemaName(string name, string schema) => schema;
   }
 }

--- a/EFCore6/src/Storage/Internal/MySQLSqlGenerationHelper.cs
+++ b/EFCore6/src/Storage/Internal/MySQLSqlGenerationHelper.cs
@@ -83,6 +83,6 @@ namespace MySql.EntityFrameworkCore.Storage.Internal
       ? _options.SchemaNameTranslator(schema, name)
       : name;
 
-    public virtual string? GetSchemaName(string name, string schema) => null;
+    public virtual string? GetSchemaName(string name, string schema) => schema;
   }
 }

--- a/EFCore7/src/Storage/Internal/MySQLSqlGenerationHelper.cs
+++ b/EFCore7/src/Storage/Internal/MySQLSqlGenerationHelper.cs
@@ -83,6 +83,6 @@ namespace MySql.EntityFrameworkCore.Storage.Internal
       ? _options.SchemaNameTranslator(schema, name)
       : name;
 
-    protected virtual string? GetSchemaName(string name, string schema) => null;
+    protected virtual string? GetSchemaName(string name, string schema) => schema;
   }
 }


### PR DESCRIPTION
Schema name are always null, it's ok when you use one database per context.
When you use multiple schemas in one EF context, the queries have to add the schema of each table before tablenames.

The bug is clearly described here :
[… EF context)](https://stackoverflow.com/questions/66244127/ef-core-mysql-multiple-schemas-in-the-same-context)
