### PR TITLE
fixed a bug where the connection was not deleted from _inUsePool. If …

### DIFF
--- a/MySQL.Data/src/MySqlConnection.cs
+++ b/MySQL.Data/src/MySqlConnection.cs
@@ -719,9 +719,7 @@ namespace MySql.Data.MySqlClient
             newDriver.currentTransaction = driver.currentTransaction;
             driver.currentTransaction.Connection = newConn;
           }
-        }
-
-        await driver.CloseAsync(execAsync).ConfigureAwait(false);
+        }        
       }
       catch (Exception ex)
       {
@@ -729,6 +727,8 @@ namespace MySql.Data.MySqlClient
       }
       finally
       {
+        await driver.CloseAsync(execAsync).ConfigureAwait(false);
+
         this.IsInUse = false;
       }
       SetState(ConnectionState.Closed, true);


### PR DESCRIPTION
…an exception occurs in a call to Driver.CreateAsync.