### PR TITLE
Fixed parallel pool creation error on start up

### DIFF
--- a/MySQL.Data/src/MySqlPoolManager.cs
+++ b/MySQL.Data/src/MySqlPoolManager.cs
@@ -191,11 +191,9 @@ namespace MySql.Data.MySqlClient
           _ = TryStartCreatingPoolAsync();
 
           pool = await poolTaskCompletionSource.Task;
-
-          pool.Settings = settings;
-
-          return pool;
         }
+
+        pool.Settings = settings;
 
         return pool;
       }


### PR DESCRIPTION
```stacktrace
System.AggregateException : One or more errors occurred. (An item with the same key has already been added. Key: server=db;port=3306;user id=u-poolingtes-0;persistsecurityinfo=True;allowuservariables=True;pooling=True;connectiontimeout=600;database=db-poolingtes-0;password=pwd;minpoolsize=10)
   ----> System.ArgumentException : An item with the same key has already been added. Key: server=db;port=3306;user id=u-poolingtes-0;persistsecurityinfo=True;allowuservariables=True;pooling=True;connectiontimeout=600;database=db-poolingtes-0;password=pwd;minpoolsize=10
   Stack Trace:
      at System.Linq.Parallel.QueryTaskGroupState.QueryEnd(Boolean userInitiatedDispose)
    at System.Linq.Parallel.SpoolingTask.SpoolForAll[TInputOutput,TIgnoreKey](QueryTaskGroupState groupState, PartitionedStream`2 partitions, TaskScheduler taskScheduler)
    at System.Linq.Parallel.DefaultMergeHelper`2.System.Linq.Parallel.IMergeHelper<TInputOutput>.Execute()
    at System.Linq.Parallel.MergeExecutor`1.Execute()
    at System.Linq.Parallel.MergeExecutor`1.Execute[TKey](PartitionedStream`2 partitions, Boolean ignoreOutput, ParallelMergeOptions options, TaskScheduler taskScheduler, Boolean isOrdered, CancellationState cancellationState, Int32 queryId)
    at System.Linq.Parallel.PartitionedStreamMerger`1.Receive[TKey](PartitionedStream`2 partitionedStream)
    at System.Linq.Parallel.ForAllOperator`1.WrapPartitionedStream[TKey](PartitionedStream`2 inputStream, IPartitionedStreamRecipient`1 recipient, Boolean preferStriping, QuerySettings settings)
    at System.Linq.Parallel.UnaryQueryOperator`2.UnaryQueryOperatorResults.ChildResultsRecipient.Receive[TKey](PartitionedStream`2 inputStream)
    at System.Linq.Parallel.ScanQueryOperator`1.ScanEnumerableQueryOperatorResults.GivePartitionedStream(IPartitionedStreamRecipient`1 recipient)
    at System.Linq.Parallel.UnaryQueryOperator`2.UnaryQueryOperatorResults.GivePartitionedStream(IPartitionedStreamRecipient`1 recipient)
    at System.Linq.Parallel.QueryOperator`1.GetOpenedEnumerator(Nullable`1 mergeOptions, Boolean suppressOrder, Boolean forEffect, QuerySettings querySettings)
    at System.Linq.Parallel.ForAllOperator`1.RunSynchronously()
    at MySql.Data.MySqlClient.Tests.PoolingTests.BasicConnection() in /app/MySQL.Data/tests/MySql.Data.Tests/PoolingTests.cs:line 51
    at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
    at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
 --ArgumentException
    at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
    at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
    at MySql.Data.MySqlClient.MySqlPoolManager.GetPoolAsync(MySqlConnectionStringBuilder settings, Boolean execAsync, CancellationToken cancellationToken) in /app/MySQL.Data/src/MySqlPoolManager.cs:line 149
    at MySql.Data.MySqlClient.MySqlConnection.OpenAsync(Boolean execAsync, CancellationToken cancellationToken) in /app/MySQL.Data/src/MySqlConnection.cs:line 650
    at MySql.Data.MySqlClient.MySqlConnection.Open() in /app/MySQL.Data/src/MySqlConnection.cs:line 581
    at MySql.Data.MySqlClient.Tests.PoolingTests.<BasicConnection>b__1_0(Int32 _) in /app/MySQL.Data/tests/MySql.Data.Tests/PoolingTests.cs:line 56
    at System.Linq.Parallel.ForAllOperator`1.ForAllEnumerator`1.MoveNext(TInput& currentElement, Int32& currentKey)
    at System.Linq.Parallel.ForAllSpoolingTask`2.SpoolingWork()
    at System.Linq.Parallel.SpoolingTaskBase.Work()
    at System.Linq.Parallel.QueryTask.BaseWork(Object unused)
    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
 --- End of stack trace from previous location ---
    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
```