### PR TITLE
Fixed bug with "RETURNING" clause of EFCore (Oracle Bug #113443)

### DIFF
--- a/EFCore/src/Update/MySQLUpdateSqlGenerator.cs
+++ b/EFCore/src/Update/MySQLUpdateSqlGenerator.cs
@@ -551,6 +551,19 @@ namespace MySql.EntityFrameworkCore
       }
     }
 
+    protected override void AppendReturningClause(StringBuilder commandStringBuilder, IReadOnlyList<IColumnModification> operations, string? additionalValues = null)
+    {
+      if (additionalValues is not null)
+      {
+        if (operations.Count > 0)
+        {
+          commandStringBuilder.Append(", ");
+        }
+
+        commandStringBuilder.Append('1');
+      }
+    }
+
     private void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
     {
       Check.NotNull(commandStringBuilder, "commandStringBuilder");


### PR DESCRIPTION
On Mar 17, 2022, [a commit was made to EFCore](https://github.com/dotnet/efcore/commit/b906ca3dd58dc89952960261e7d6eea766d4a7b4), introducing a new method called [`AppendReturningClause`](https://github.com/dotnet/efcore/blob/main/src/EFCore.Relational/Update/UpdateSqlGenerator.cs#L500).

If a data class, has a property that is annotated with `[DatabaseGenerated(DatabaseGeneratedOption.Computed)]` attribute, when updating data in this table, the `AppendReturningClause` method will add a `RETURNING` clause to the generated SQL.
MySQL does not support the `RETURNING` clause, and MySQL.EntityFrameworkCore did not override this method, causing the update operation to fail in some scenarios.
I have created a bug in "MySQL bug tracker".
The bug link is https://bugs.mysql.com/bug.php?id=113443

Below is two screenshots of source code that can repro this bug:
![image](https://github.com/mysql/mysql-connector-net/assets/2684991/9d2bcf0a-bd7c-4a80-b8d2-45860537c730)

![image](https://github.com/mysql/mysql-connector-net/assets/2684991/07dfff13-2781-4650-bd9d-f2e414bcf2dd)

This is the SQL that EFCore generated when the bug is triggered:
``` sql
UPDATE `sample_table` SET `name` = @p0
WHERE `id` = @p1
RETURNING `time_created`, `time_updated`
```