### PR TITLE
Fix deadlock in mysql poolmanager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+8.2.1
+- Fixed deadlock bug in MySqlPoolManager.GetPoolAsync affecting apps with SynchronizationContext like ASP.NET MVC full framework app, Windows Forms app, WPF app.
+
+
 8.2.0
 - Migrated installer to Wix 4.0 (WL15847).
 - Fixed bug Opening two MySqlConnections simultaneously can crash (Oracle Bug #35307501).

--- a/Documentation/templates/custom/partials/class.header.tmpl.partial
+++ b/Documentation/templates/custom/partials/class.header.tmpl.partial
@@ -25,7 +25,7 @@
 {{/implements.0}}
 <h6><strong>{{__global.namespace}}</strong>: {{{namespace.specName.0.value}}}</h6>
 <h6><strong>{{__global.assembly}}</strong>: {{assemblies.0}}.dll</h6>
-<h6><strong>Version</strong>: 8.2.0</h6>
+<h6><strong>Version</strong>: 8.2.1</h6>
 <h5 id="{{id}}_syntax">{{__global.syntax}}</h5>
 <div class="codewrapper">
   <pre><code class="lang-{{_lang}} hljs">{{syntax.content.0.value}}</code></pre>

--- a/EFCore/Directory.Build.targets
+++ b/EFCore/Directory.Build.targets
@@ -1,16 +1,16 @@
 <Project>
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <Copyright>Copyright (c) 2021, 2023, Oracle and/or its affiliates.</Copyright>
-    <Version>6.0.21+MySQL8.2.0</Version>
+    <Version>6.0.21+MySQL8.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
     <Copyright>Copyright (c) 2022, 2023, Oracle and/or its affiliates.</Copyright>
-    <Version>7.0.10+MySQL8.2.0</Version>
+    <Version>7.0.10+MySQL8.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
     <Copyright>Copyright (c) 2023, Oracle and/or its affiliates.</Copyright>
-    <Version>8.0.0-preview+MySQL8.2.0</Version>
+    <Version>8.0.0-preview+MySQL8.2.1</Version>
   </PropertyGroup>
 </Project>

--- a/EntityFramework/src/MySql.Data.EntityFramework.csproj
+++ b/EntityFramework/src/MySql.Data.EntityFramework.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Data.EntityFramework</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net462;netstandard2.1;</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/EntityFramework/tests/MySql.EntityFramework.Basic.Tests/MySql.EntityFramework.Basic.Tests.csproj
+++ b/EntityFramework/tests/MySql.EntityFramework.Basic.Tests/MySql.EntityFramework.Basic.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Data.EntityFramework.CodeFirTests</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>MySql.EntityFramework.Basic.Tests</AssemblyName>

--- a/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/MySql.EntityFramework.CodeFirst.Tests.csproj
+++ b/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/MySql.EntityFramework.CodeFirst.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Data.EntityFramework.CodeFirst.Tests</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>MySql.EntityFramework.CodeFirst.Tests</AssemblyName>

--- a/EntityFramework/tests/MySql.EntityFramework.Migrations.Tests/MySql.EntityFramework.Migrations.Tests.csproj
+++ b/EntityFramework/tests/MySql.EntityFramework.Migrations.Tests/MySql.EntityFramework.Migrations.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Data.EntityFramework.Migrations.Tests</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>MySql.EntityFramework.Migrations.Tests</AssemblyName>

--- a/MySQL.Data.OpenTelemetry/src/MySQL.Data.OpenTelemetry.csproj
+++ b/MySQL.Data.OpenTelemetry/src/MySQL.Data.OpenTelemetry.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Data.OpenTelemetry</Description>
     <Copyright>Copyright (c) 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>  
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MySql.Data.OpenTelemetry</AssemblyName>

--- a/MySQL.Data/src/MySql.Data.csproj
+++ b/MySQL.Data/src/MySql.Data.csproj
@@ -5,7 +5,7 @@
     <Description>MySql.Data.MySqlClient .Net Core Class Library</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <AssemblyName>MySql.Data</AssemblyName>
     <TargetFrameworks>net462;net48;netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;</TargetFrameworks>

--- a/MySQL.Data/src/MySqlPoolManager.cs
+++ b/MySQL.Data/src/MySqlPoolManager.cs
@@ -139,7 +139,7 @@ namespace MySql.Data.MySqlClient
     {
       string text = GetKey(settings);
 
-      await waitHandle.WaitAsync(CancellationToken.None);
+      await waitHandle.WaitAsync(CancellationToken.None).ConfigureAwait(false);
       MySqlPool pool;
       Pools.TryGetValue(text, out pool);
 
@@ -209,7 +209,7 @@ namespace MySql.Data.MySqlClient
 
     public static async Task ClearAllPoolsAsync(bool execAsync)
     {
-      await waitHandle.WaitAsync();
+      await waitHandle.WaitAsync().ConfigureAwait(false);
 
       // Create separate keys list.
       List<string> keys = new List<string>(Pools.Count);

--- a/MySQL.Data/src/Properties/VersionInfo.cs
+++ b/MySQL.Data/src/Properties/VersionInfo.cs
@@ -40,6 +40,6 @@ using System.Resources;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("8.2.0")]
-[assembly: AssemblyInformationalVersion("8.2.0")]
+[assembly: AssemblyVersion("8.2.1")]
+[assembly: AssemblyInformationalVersion("8.2.1")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/MySQL.Data/tests/MySql.Data.Tests/MySql.Data.Tests.csproj
+++ b/MySQL.Data/tests/MySql.Data.Tests/MySql.Data.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Framework\netstandard2_0\PartialTrustSandbox.cs" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MySQL.Data/tests/MySql.Data.Tests/MySql.Data.Tests.csproj
+++ b/MySQL.Data/tests/MySql.Data.Tests/MySql.Data.Tests.csproj
@@ -4,7 +4,7 @@
     <Title>MySql.Data.Tests</Title>
     <Description>MySql.Data.Tests Class Library</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.</Copyright>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <Company>Oracle</Company>
     <Product>MySql.Data.Tests</Product>

--- a/MySQL.Data/tests/MySqlX.Data.Tests/MySqlX.Data.Tests.csproj
+++ b/MySQL.Data/tests/MySqlX.Data.Tests/MySqlX.Data.Tests.csproj
@@ -4,7 +4,7 @@
     <Title>MySql.Data.Tests</Title>
     <Description>MySql.Data.Tests Class Library</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.</Copyright>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <Company>Oracle</Company>
     <Product>MySql.Data.Tests</Product>

--- a/MySql.Web/src/MySql.Web.csproj
+++ b/MySql.Web/src/MySql.Web.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Web</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net462;net48;</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/MySql.Web/tests/MySql.Web.Tests.csproj
+++ b/MySql.Web/tests/MySql.Web.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>MySql.Web.Tests</Description>
     <Copyright>Copyright (c) 2016, 2023, Oracle and/or its affiliates.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>Oracle</Authors>
     <TargetFrameworks>net462;net48;</TargetFrameworks>
     <AssemblyName>MySql.Web.Tests</AssemblyName>


### PR DESCRIPTION
There is **deadlock** bug in *MySqlPoolManager.cs*. It makes the library unusable in any .Net applications with SynchronizationCotnext while using pooling feature.

It causes a deadlock of threads, application will hang forever. Affected are:
- ASP .NET MVC app (on full .net framework),
- Windows Forms App,
- WPF app.
If using *Pooling=true* in connection string (common scenario).

What is more, it leads to breaking the whole appPool on IIS (for ASP .NET MVC app) as all threads from thread pool will eventually deadlock.

This looks like obvious human error, there is missing *ConfigureAwait(false)* when awaiting on semaphore. Note that the *ConfigureAwait(false)* is widely used in all other places at this class but in this one is simply missing.
```
await waitHandle.WaitAsync(CancellationToken.None);
```
In this PR:
- Two places in *MySqlPoolManager.cs* are fixed to not cause deadlock
- Changelog and library version updated (I hope this critical bugfix will reach all users sooner than later)
- Unit test which allows to reproduce the issue (for the sake of simplicity I included only one of the SynchronizationContext scenario to demonstrate deadlock).

How bug was introduced
1. On 11 Jan 2023 there was [change](https://github.com/mysql/mysql-connector-net/commit/291c2f31fa9d7bf1b3c02bd7da19db1b66f89abd#diff-2f7f47ba68ef3657e2af3b9aa32b7623603ffb60834a8b894bf723ad3e2f9e25R141) from using *lock* to *SemaphoreSlim* in *MySqlPoolManager.GetPoolAsync*. Unfortunatelly this introduced a bug - the new Semaphore was created every time method is invoked so there was no threadsaffenes at all.
2. The bug from 1. was [fixed](https://github.com/mysql/mysql-connector-net/commit/37351fc2a4d19e954edbaba79eac80153d0f5388) by setting the semaphore *static* so the thread safeness was introduced again. Unfortunately acquiring the lock on semaphore is done asynchronously without using *ConfigureAwait(false)* so it causes deadlocks in described in this PR scenarios.