### PR TITLE
WIP Ensure sql statements end up in ActivitySource

### DIFF
--- a/MySQL.Data/src/MySQLActivitySource.cs
+++ b/MySQL.Data/src/MySQLActivitySource.cs
@@ -67,7 +67,7 @@ namespace MySql.Data
     }
 
 
-    internal static Activity CommandStart(MySqlCommand command)
+    internal static Activity CommandStart(MySqlCommand command, string sql)
     {
       if (!Active) return null;
 
@@ -81,7 +81,7 @@ namespace MySql.Data
       activity?.SetTag("db.system", "mysql");
       activity?.SetTag("db.name", command.Connection.Database);
       activity?.SetTag("db.user", command.Connection.Settings.UserID);
-      activity?.SetTag("db.statement", command.OriginalCommandText);
+      activity?.SetTag("db.statement", sql);
       activity?.SetTag("thread.id", Thread.CurrentThread.ManagedThreadId);
       activity?.SetTag("thread.name", Thread.CurrentThread.Name);
       if (command.CommandType == CommandType.TableDirect)

--- a/MySQL.Data/src/MySqlCommand.cs
+++ b/MySQL.Data/src/MySqlCommand.cs
@@ -760,7 +760,7 @@ namespace MySql.Data.MySqlClient
 
       // Tell whoever is listening that we have started out command
 #if NET5_0_OR_GREATER
-      CurrentActivity = MySQLActivitySource.CommandStart(this);
+      CurrentActivity = MySQLActivitySource.CommandStart(this, sql);
 #endif
       try
       {


### PR DESCRIPTION
There are quite a few ways for an sql statement to wound up being executed, including but not only:

1. Passing it into the `MySQLCommand` constructor
2. Assigning a `MySQLCommand` instance's `CommandText`
3. Using `CommandType.TableDirect` with a table name
4. Using a stored procedure
5. ...with parameters
6. Opening a connection

And probably more. The existing bridge into the `ActivitySource` answers some of them, and this commit hopes to bridge some of the gap. Namely:

- Scenario 2 (`CommandText` assignment)
- Scenario 3 (`TableDirect`) shows the actually executing SQL

This commit is currently to be considered in a draft state; it is not ready to be merged. Inline review comments will be added for clarifications and questions.