### PR TITLE
Fix: None of the discovered or specified addresses match the socket address family.

### DIFF
--- a/MySQL.Data/src/common/StreamCreator.cs
+++ b/MySQL.Data/src/common/StreamCreator.cs
@@ -109,9 +109,9 @@ namespace MySql.Data.Common
 
       if (execAsync)
         using (cancellationToken.Register(() => throw new MySqlException(Resources.Timeout, new TimeoutException())))
-          await tcpClient.ConnectAsync(settings.Server, (int)settings.Port).ConfigureAwait(false);
+          await tcpClient.ConnectAsync(addr, (int)settings.Port).ConfigureAwait(false);
       else
-        if (!tcpClient.ConnectAsync(settings.Server, (int)settings.Port).Wait((int)settings.ConnectionTimeout * 1000))
+        if (!tcpClient.ConnectAsync(addr, (int)settings.Port).Wait((int)settings.ConnectionTimeout * 1000))
         throw new MySqlException(Resources.Timeout, new TimeoutException());
 
       if (settings.Keepalive > 0)


### PR DESCRIPTION
When server is specified as the host name, if the LAN host has both IPv4 and IPv6 addresses and the IPv6 address is located in the first address returned by Dns.GetHostAddresses(), the socket will not be connected. Because the TcpClient was created using the IPv4 address family, but the socket re-resolved the hostname and got an IPv6 address.

![Snipaste_2024-05-09_14-55-29](https://github.com/mysql/mysql-connector-net/assets/20726245/51135b10-d9d0-46fa-8f59-9984c89405e9)
![Snipaste_2024-05-09_15-15-06](https://github.com/mysql/mysql-connector-net/assets/20726245/07ff7fba-b589-4be4-b8a1-94691aa0c854)
