### PR TITLE
Use ActualColumnName for joins

### DIFF
--- a/EntityFramework/src/Statements/SelectStatement.cs
+++ b/EntityFramework/src/Statements/SelectStatement.cs
@@ -232,7 +232,7 @@ namespace MySql.Data.EntityFramework
           if (generator.GetTopOp() == OpType.Join)
           {
             newColumn.ColumnAlias = cf.ColumnAlias;
-            newColumn.PushInput(cf.ColumnName);
+            newColumn.PushInput(cf.ActualColumnName);
             if (cf.TableName != null)
               newColumn.PushInput(cf.TableName);
           }

--- a/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/CodeFirstTests.cs
+++ b/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/CodeFirstTests.cs
@@ -192,6 +192,46 @@ namespace MySql.Data.EntityFramework.CodeFirst.Tests
     }
 
     /// <summary>
+    /// Tests for fix of http://bugs.mysql.com/bug.php?id=116028
+    /// Incorrect discriminator generated column values when it's used code-first, inheritance and in a join statement
+    /// </summary>
+    [Test]
+    public void Bug116028_Test1()
+    {
+    #if DEBUG
+      Debug.WriteLine(new StackTrace().GetFrame(0).GetMethod().Name);
+    #endif
+      List<Vehicle4> vehicles;
+      using (VehicleDbContext4 context = new VehicleDbContext4())
+      {
+        context.Database.Delete();
+        context.Database.Initialize(true);
+        var manuf = context.Manufacturers.Add(new Manufacturer4 { Name = "ACME" });
+        context.Vehicles.Add(new Car4 { Id = 1, Name = "Mustang", Year = 2012, CarProperty = "Car", Manufacturer = manuf });
+        context.Vehicles.Add(new Bike4 { Id = 101, Name = "Mountain", Year = 2011, BikeProperty = "Bike", Manufacturer = manuf });
+        context.SaveChanges();
+
+        vehicles = context.Manufacturers.SelectMany(v => v.Vehicles).ToList();
+
+        int records = -1;
+        using (MySqlConnection conn = new MySqlConnection(context.Database.Connection.ConnectionString))
+        {
+          conn.Open();
+          MySqlCommand cmd = new MySqlCommand("SELECT COUNT(*) FROM Vehicles", conn);
+          records = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        Assert.AreEqual(context.Vehicles.Count(), records);
+      }
+      using (VehicleDbContext4 context = new VehicleDbContext4())
+      {
+        var vehiclesfromdb = context.Manufacturers.SelectMany(v => v.Vehicles).ToList();
+        Assert.AreEqual(vehicles.OfType<Car4>().Single().CarProperty, vehiclesfromdb.OfType<Car4>().Single().CarProperty);
+        Assert.AreEqual(vehicles.OfType<Bike4>().Single().BikeProperty, vehiclesfromdb.OfType<Bike4>().Single().BikeProperty);
+      }
+    }
+
+    /// <summary>
     /// Tests for fix of http://bugs.mysql.com/bug.php?id=63920
     /// Maxlength error when it's used code-first and inheritance (discriminator generated column)
     /// </summary>

--- a/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/Vehicle.cs
+++ b/EntityFramework/tests/MySql.EntityFramework.CodeFirst.Tests/Vehicle.cs
@@ -117,7 +117,57 @@ namespace MySql.Data.EntityFramework.CodeFirst.Tests
 
   }
   }
+  public class Car4 : Vehicle4
+  {
+    public string CarProperty { get; set; }
+  }
 
+  public class Bike4 : Vehicle4
+  {
+    public string BikeProperty { get; set; }
+  }
+  public class Manufacturer4
+  {
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public Guid ManufacturerId { get; set; }
+    public string Name { get; set; }
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public Guid GroupIdentifier { get; set; }
+    public virtual ICollection<Vehicle4> Vehicles { get; set; }
+  }
+  public class Vehicle4
+  {
+    public int Id { get; set; }
+    public int Year { get; set; }
+
+    [MaxLength(1024)]
+    public string Name { get; set; }
+    public Guid ManufacturerId { get; set; }
+    [ForeignKey(nameof(ManufacturerId))]
+    public virtual Manufacturer4 Manufacturer { get; set; }
+  }
+  [DbConfigurationType(typeof(MySqlEFConfiguration))]
+  public class VehicleDbContext4 : DbContext
+  {
+    public DbSet<Vehicle4> Vehicles { get; set; }
+    public DbSet<Manufacturer4> Manufacturers { get; set; }
+
+    public VehicleDbContext4() : base(CodeFirstFixture.GetEFConnectionString<VehicleDbContext4>())
+    {
+      Database.SetInitializer<VehicleDbContext4>(new VehicleDBInitializer4());
+
+    }
+    protected override void OnModelCreating(DbModelBuilder modelBuilder)
+    {
+      modelBuilder.Entity<Vehicle4>().ToTable("Vehicles");
+      modelBuilder.Entity<Car4>().ToTable("Cars");
+      modelBuilder.Entity<Bike4>().ToTable("Bikes");
+    }
+  }
+  public class VehicleDBInitializer4 : DropCreateDatabaseReallyAlways<VehicleDbContext4>
+  {
+  }
   public class Accessory
   {
     [Key]


### PR DESCRIPTION
Fixes Bugzilla #116028, where the generated discriminator column carries the incorrect values resulting in the incorrect materialization of type hierarchies.