### PR TITLE
add repository urls

### DIFF
--- a/EFCore/src/MySql.EntityFrameworkCore.csproj
+++ b/EFCore/src/MySql.EntityFrameworkCore.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://github.com/mysql/mysql-connector-net</PackageProjectUrl>
     <PackageLicenseExpression>GPL-2.0-only WITH Universal-FOSS-exception-1.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/mysql/mysql-connector-net</RepositoryUrl>
     <LangVersion>10.0</LangVersion>
     <TargetFrameworks>net6.0;net8.0;</TargetFrameworks>
     <AssemblyName>MySql.EntityFrameworkCore</AssemblyName>

--- a/EntityFramework/src/MySql.Data.EntityFramework.csproj
+++ b/EntityFramework/src/MySql.Data.EntityFramework.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://dev.mysql.com/downloads/</PackageProjectUrl>
     <PackageLicenseExpression>GPL-2.0-only WITH Universal-FOSS-exception-1.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/mysql/mysql-connector-net</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/MySQL.Data.OpenTelemetry/src/MySQL.Data.OpenTelemetry.csproj
+++ b/MySQL.Data.OpenTelemetry/src/MySQL.Data.OpenTelemetry.csproj
@@ -13,8 +13,9 @@
     <PackageIcon>logo-mysql-170x115.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://dev.mysql.com/downloads/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mysql/mysql-connector-net</RepositoryUrl>
     <PackageLicenseExpression>GPL-2.0-only WITH Universal-FOSS-exception-1.0</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>True</SignAssembly>
     <DelaySign>True</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\ConnectorNetPublicKey.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This PR adds the repository urls that are currently missing on the NuGet page overview, as recommended in the NuGet guidelines.

![image](https://github.com/user-attachments/assets/21e34a7b-f3e9-4e40-a6c1-38b43d5fac0f)

Feel free to reject this PR and implement it yourself, but I guess you'll understand that I don't want to register on bugs.mysql.org. That page is slow, overcomplicated, user-unfriendly and clumsy :-(