### PR TITLE
Add big-endian support in MySqlX protocol handling

### DIFF
--- a/MySQL.Data/src/X/Communication/XCompressionController.cs
+++ b/MySQL.Data/src/X/Communication/XCompressionController.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using ZstdSharp;
+using System.Buffers.Binary;
 
 namespace MySqlX.Communication
 {
@@ -329,7 +330,7 @@ namespace MySqlX.Communication
 
       var messageSizeBytes = new byte[4];
       Buffer.BlockCopy(decompressedData, 0, messageSizeBytes, 0, messageSizeBytes.Length);
-      var firstMessageSize = BitConverter.ToInt32(messageSizeBytes, 0) + 4;
+      var firstMessageSize = BinaryPrimitives.ReadInt32LittleEndian(messageSizeBytes.AsSpan().Slice(0)) + 4;
       LastMessageContainsMultipleMessages = firstMessageSize < decompressedData.Length;
       if (!LastMessageContainsMultipleMessages
           || (_multipleMessagesStream != null
@@ -440,7 +441,7 @@ namespace MySqlX.Communication
       var messageSizeBytes = new byte[4];
       _multipleMessagesStream.Read(messageSizeBytes, 0, messageSizeBytes.Length);
       byte messageType = (byte)_multipleMessagesStream.ReadByte();
-      var messageSize = BitConverter.ToInt32(messageSizeBytes, 0);
+      var messageSize = BinaryPrimitives.ReadInt32LittleEndian(messageSizeBytes.AsSpan().Slice(0));
       var data = new byte[messageSize - 1];
       _multipleMessagesStream.Read(data, 0, data.Length);
       _lastCommunicationPacket = new CommunicationPacket(messageType, messageSize - 1, data);

--- a/MySQL.Data/src/X/Communication/XPacketProcessor.cs
+++ b/MySQL.Data/src/X/Communication/XPacketProcessor.cs
@@ -37,6 +37,7 @@ using MySqlX.XDevAPI.Common;
 using System.Linq;
 using System.Net.Sockets;
 using System.Collections.Generic;
+using System.Buffers.Binary;
 
 namespace MySql.Data.X.Communication
 {
@@ -153,7 +154,7 @@ namespace MySql.Data.X.Communication
 
       byte[] header = new byte[HEADER_SIZE];
       ReadFully(header, 0, HEADER_SIZE);
-      int length = BitConverter.ToInt32(header, 0);
+      int length = BinaryPrimitives.ReadInt32LittleEndian(header.AsSpan().Slice(0));
       byte[] data = new byte[length - 1];
       ReadFully(data, 0, length - 1);
       // If compression is enabled and message is of type compression.
@@ -168,7 +169,7 @@ namespace MySql.Data.X.Communication
         {
           data[i] = decompressedPayload[i + HEADER_SIZE];
         }
-        returnPacket = new CommunicationPacket(decompressedPayload[MESSAGE_TYPE], BitConverter.ToInt32(decompressedPayload, 0) - 1, data);
+        returnPacket = new CommunicationPacket(decompressedPayload[MESSAGE_TYPE], BinaryPrimitives.ReadInt32LittleEndian(decompressedPayload.AsSpan().Slice(0)) - 1, data);
         IdentifyPacket(returnPacket);
         return returnPacket;
       }

--- a/MySQL.Data/src/X/Communication/XPacketReaderWriter.cs
+++ b/MySQL.Data/src/X/Communication/XPacketReaderWriter.cs
@@ -34,6 +34,7 @@ using Mysqlx.Connection;
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Buffers.Binary;
 
 namespace MySqlX.Communication
 {
@@ -96,7 +97,8 @@ namespace MySqlX.Communication
         var messageHeader = new byte[5];
         var messageBytes = message.ToByteArray();
         byte[] payload = new byte[messageHeader.Length + messageBytes.Length];
-        var sizeArray = BitConverter.GetBytes(messageSize + 1);
+        byte[] sizeArray = new byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(sizeArray,(messageSize + 1));
         Buffer.BlockCopy(sizeArray, 0, messageHeader, 0, sizeArray.Length);
         messageHeader[4] = (byte)id;
         Buffer.BlockCopy(messageHeader, 0, payload, 0, messageHeader.Length);
@@ -108,7 +110,9 @@ namespace MySqlX.Communication
         compression.Payload = ByteString.CopyFrom(CompressionWriteController.Compress(payload));
 
         // Build the X Protocol frame.
-        _stream.Write(BitConverter.GetBytes(compression.CalculateSize() + 1), 0, 4);
+        byte[] bytesToWrite = new byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(bytesToWrite,(compression.CalculateSize() + 1));
+        _stream.Write(bytesToWrite, 0, 4);
         _stream.WriteByte((byte)(ClientMessageId.COMPRESSION));
         if (messageSize > 0)
         {
@@ -117,7 +121,9 @@ namespace MySqlX.Communication
       }
       else
       {
-        _stream.Write(BitConverter.GetBytes(messageSize + 1), 0, 4);
+        byte[] bytesToWrite = new byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(bytesToWrite,messageSize + 1);
+        _stream.Write(bytesToWrite, 0, 4);
         _stream.WriteByte((byte)id);
         if (messageSize > 0)
         {


### PR DESCRIPTION
Add big-endian support in MySqlX protocol handling.The MySqlX protocol doesn't work on big-endian systems. This error stems mostly from the use of BitConverter function used in method definitions across the code and improper byte ordering for big endian systems.

The BitConverter class does conversions according to the endianess of the system it is operating on which causes incorrect reads of little-endian packets sent by the server.