### PR TITLE
MySqlPoolManager.Pools use ConcurrentDictionary

### DIFF
--- a/MySQL.Data/src/MySqlPoolManager.cs
+++ b/MySQL.Data/src/MySqlPoolManager.cs
@@ -46,7 +46,7 @@ namespace MySql.Data.MySqlClient
   /// </summary>
   internal class MySqlPoolManager
   {
-    private static readonly Dictionary<string, MySqlPool> Pools = new Dictionary<string, MySqlPool>();
+    private static readonly ConcurrentDictionary<string, MySqlPool> Pools = new ConcurrentDictionary<string, MySqlPool>();
     private static readonly List<MySqlPool> ClearingPools = new List<MySqlPool>();
     internal const int DEMOTED_TIMEOUT = 120000;
     private static SemaphoreSlim waitHandle = new(1, 1);
@@ -151,7 +151,7 @@ namespace MySql.Data.MySqlClient
         if (pool == null)
         {
           pool = await MySqlPool.CreateMySqlPoolAsync(settings, execAsync, cancellationToken).ConfigureAwait(false);
-          Pools.Add(text, pool);
+          Pools.TryAdd(text, pool);
         }
         else
           pool.Settings = settings;
@@ -221,7 +221,7 @@ namespace MySql.Data.MySqlClient
         await pool.ClearAsync(execAsync).ConfigureAwait(false);
 
         // and then remove the pool from the active pools list
-        Pools.Remove(key);
+        Pools.TryRemove(key, out var _);
       }
       finally
       {
@@ -272,7 +272,7 @@ namespace MySql.Data.MySqlClient
 
       lock (Pools)
       {
-        foreach (MySqlPool pool in Pools.Keys.Select(key => Pools[key]))
+        foreach (MySqlPool pool in Pools.Values)
         {
           oldDrivers.AddRange(pool.RemoveOldIdleConnections());
         }


### PR DESCRIPTION
Report a bug.

Exception：
<img width="1187" height="126" alt="Screenshot 2025-12-25 at 14 37 44" src="https://github.com/user-attachments/assets/0f743c8b-daa2-4962-9ac7-1d06fc08372a" />

Reason:
The Timer thread in C# calls the CleanIdleConnections method to traverse the Pools dictionary, while other threads add or remove data from the Pools dictionary, which may cause a concurrent modification exception.

Fix：
Use ConcurrentDictionary to solve this problem.