### PR TITLE
Add support for  type mapping in EF Core 10 (MySQL Connector/NET)Add support for string[] type mapping in EF Core 10

### DIFF
--- a/EFCore/src/Storage/Internal/MySQLTypeMappingSource.cs
+++ b/EFCore/src/Storage/Internal/MySQLTypeMappingSource.cs
@@ -284,7 +284,7 @@ namespace MySql.EntityFrameworkCore.Storage.Internal
 
           return mapping;
         }
-        else if (clrType == typeof(string))
+        else if (clrType == typeof(string) || clrType == typeof(string[]))
         {
           var isAnsi = mappingInfo.IsUnicode == false;
           var isFixedLength = mappingInfo.IsFixedLength == true;

--- a/EFCore/tests/MySql.EFCore.Basic.Tests/StringArrayTest.cs
+++ b/EFCore/tests/MySql.EFCore.Basic.Tests/StringArrayTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+using MySql.EntityFrameworkCore.Basic.Tests.Utils;
+using MySql.EntityFrameworkCore.Infrastructure.Internal;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using static MySql.EntityFrameworkCore.Basic.Tests.BasicGuidTests;
+namespace MySql.EntityFrameworkCore.Basic.Tests
+{
+    public class StringArrayTest
+    {
+        [Test]
+        public void TestStringArray()
+        {
+            using var context = new ContextStringArray();
+            string[] stringArray = new string[] { "TEST" };
+            var stockCodeMAtch = context.StringCodeMatch.FirstOrDefault(q => stringArray.Contains(q.Code));
+        }
+
+        public class StringCodeMatch
+        {
+            [Key]
+            public int RecordID { get; set; }
+            public string Code { get; set; }
+        }
+        public class ContextStringArray : DbContext
+        {
+            public DbSet<StringCodeMatch> StringCodeMatch { get; set; }
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                if (!optionsBuilder.IsConfigured
+                  || optionsBuilder.Options.FindExtension<MySQLOptionsExtension>() == null)
+                {
+                    optionsBuilder.UseMySQL($"server=localhost;user=root;database=DbContextStringArray;CharSet=utf8;Pooling=false;");
+                }
+            }
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces support for string[] type mapping in the MySQL EF Core provider.
Problem
When using EF Core 10 with MySQL, queries that rely on Contains with a string[] fail with the following exception:

``InvalidOperationException: Expression '@stringArray' in the SQL tree does not have a type mapping assigned.'`

This occurs because the provider does not currently assign a relational type mapping for string collections, even though EF Core 10 expects it.

Solution

The type mapping source has been updated to handle both string and string[]:

```
else if (clrType == typeof(string) || clrType == typeof(string[]))
{
    // existing string mapping logic
}
```

This ensures that string[] is recognized and mapped correctly, allowing queries such as:

`            string[] stringArray = new string[] { "TEST" };
            var result = context.StringCodeMatch.FirstOrDefault(q => stringArray.Contains(q.Code));`

to execute without error.