### PR TITLE
Apply type mappings to collated expressions

### DIFF
--- a/EFCore/src/Query/Internal/MySQLSqlExpressionFactory.cs
+++ b/EFCore/src/Query/Internal/MySQLSqlExpressionFactory.cs
@@ -293,7 +293,13 @@ namespace MySql.EntityFrameworkCore.Query.Internal
     private MySQLCollateExpression ApplyTypeMappingOnCollate(MySQLCollateExpression collateExpression)
     {
 #if NET9_0_OR_GREATER
-      return new MySQLCollateExpression(collateExpression.Operand, collateExpression.Charset, collateExpression.Collation);
+      var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(collateExpression.Operand)
+  ?? _typeMappingSource.FindMapping(collateExpression.Operand.Type);
+
+      return new MySQLCollateExpression(
+          ApplyTypeMapping(collateExpression.Operand, inferredTypeMapping),
+          collateExpression.Charset,
+          collateExpression.Collation);
 #else
       var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(collateExpression.ValueExpression)
   ?? _typeMappingSource.FindMapping(collateExpression.ValueExpression.Type);

--- a/EFCore/tests/MySql.EFCore.Basic.Tests/EFCoreTests.cs
+++ b/EFCore/tests/MySql.EFCore.Basic.Tests/EFCoreTests.cs
@@ -292,5 +292,17 @@ namespace MySql.EntityFrameworkCore.Basic.Tests
         }
       }
     }
+
+    [Test]
+    public void StringComparisonCheck()
+    {
+      using (SakilaLiteContext context = new SakilaLiteContext())
+      {
+        context.InitContext();
+                
+        var test = context.Customer.Where(x => x.LastName!.StartsWith("SMIT", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.That(test.Count, Is.GreaterThan(0));
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently in EFCore 9 and 10 using string comparison functions such as string.StartsWith(string), string.EndsWith(string), string.Equals(string, StringComparison) will fail due to the type mapping not being applied to the MySQLCollateExpression.

This update uses previous logic on applying the inferred type mapping to the MySQLCollateExpression.Operand before returning a new MySQLCollateExpression.