### PR TITLE
Fix .Contains and collated expression type mappings

### DIFF
--- a/EFCore/src/Query/Internal/MySQLSqlExpressionFactory.cs
+++ b/EFCore/src/Query/Internal/MySQLSqlExpressionFactory.cs
@@ -236,6 +236,51 @@ namespace MySql.EntityFrameworkCore.Query.Internal
         _ => base.ApplyTypeMapping(sqlExpression, typeMapping)
       };
 
+
+#if NET10_0_OR_GREATER
+	/// <summary>
+	///   Overrides the base <c>In(item, valuesParameter)</c> so that the resulting <see cref="InExpression"/>'s
+	///   <see cref="InExpression.ValuesParameter"/> always carries a non-null type mapping.
+	/// </summary>
+	/// <remarks>
+	///   <para>
+	///     The base implementation looks up a collection type mapping via
+	///     <c>TypeMappingSource.FindMapping(valuesParameter.Type, model, elementMapping)</c>.
+	///     This can leave the values parameter unmapped if the parameter is an IEnumerable
+	///   </para>
+	/// </remarks>
+	public override SqlExpression In(SqlExpression item, SqlParameterExpression valuesParameter)
+	{
+		var inExpression = (InExpression)base.In(item, valuesParameter);
+	
+		if (inExpression.ValuesParameter is not { TypeMapping: null } unmappedValuesParameter)
+		{
+			return inExpression;
+		}
+		
+		var model = Dependencies.Model;
+		var elementMapping = inExpression.Item.TypeMapping
+							 ?? _typeMappingSource.FindMapping(inExpression.Item.Type, model);
+		if (elementMapping is null)
+		{
+			return inExpression;
+		}
+	
+		// Back-apply the element mapping to the item if it was missing one.
+		var mappedItem = inExpression.Item.TypeMapping is null
+			? ApplyTypeMapping(inExpression.Item, elementMapping)
+			: inExpression.Item;
+	
+		var collectionMapping = _typeMappingSource.FindMapping(unmappedValuesParameter.Type, model, elementMapping);
+		if (collectionMapping is null)
+		{
+			collectionMapping = (RelationalTypeMapping)elementMapping.Clone(elementMapping: elementMapping);
+		}
+	
+		return inExpression.Update(mappedItem, unmappedValuesParameter.ApplyTypeMapping(collectionMapping));
+	}
+#endif
+
     private SqlBinaryExpression ApplyTypeMappingOnSqlBinary(SqlBinaryExpression sqlBinaryExpression, RelationalTypeMapping typeMapping)
     {
       // The default SqlExpressionFactory behavior is to assume that the two operands have the same type, and so to infer one side's
@@ -292,8 +337,13 @@ namespace MySql.EntityFrameworkCore.Query.Internal
 
     private MySQLCollateExpression ApplyTypeMappingOnCollate(MySQLCollateExpression collateExpression)
     {
-#if NET9_0_OR_GREATER
-      return new MySQLCollateExpression(collateExpression.Operand, collateExpression.Charset, collateExpression.Collation);
+#if NET9_0_OR_GREATER 
+      var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(collateExpression.Operand)
+                                ?? _typeMappingSource.FindMapping(collateExpression.Operand.Type);
+      return new MySQLCollateExpression(
+        ApplyTypeMapping(collateExpression.Operand, inferredTypeMapping),
+        collateExpression.Charset,
+        collateExpression.Collation);
 #else
       var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(collateExpression.ValueExpression)
   ?? _typeMappingSource.FindMapping(collateExpression.ValueExpression.Type);

--- a/EFCore/tests/MySql.EFCore.Basic.Tests/BasicGuidTests.cs
+++ b/EFCore/tests/MySql.EFCore.Basic.Tests/BasicGuidTests.cs
@@ -53,24 +53,42 @@ namespace MySql.EntityFrameworkCore.Basic.Tests
     public void TestEmptyGUID()
     {
       MySQLTestStore.Execute("drop database if exists DbContextGuid; Create database DbContextGuid; ");
-      using (var context = new ContextGUID())
-      {
-        context.Database.EnsureDeleted();
-        context.Database.EnsureCreated();
-        var filter = new[] { Guid.Empty };
-        var resultFilter = context.Guidtable.Where(t => filter.Contains(t.Uuid)).ToArray();
-        Assert.That(resultFilter, Is.Not.Null);
-        Random rnd = new Random();
-        var guid = Guid.NewGuid();
-        var record = new GuidTable { Id = rnd.Next(100), Uuid = guid };
-        context.Guidtable.Add(record);
-        context.SaveChanges();
-        var rows = context.Guidtable.Count();
-        Assert.That(rows, Is.EqualTo(1));
-        filter[0] = guid;
-        var resultFilter2 = context.Guidtable.Where(t => filter.Contains(t.Uuid)).ToArray();
-        Assert.That(resultFilter2.Count(), Is.EqualTo(1));
-      }
+      using var context = new ContextGUID();
+      context.Database.EnsureDeleted();
+      context.Database.EnsureCreated();
+      var filter = new[] { Guid.Empty };
+      var resultFilter = context.Guidtable.Where(t => filter.Contains(t.Uuid)).ToArray();
+      Assert.That(resultFilter, Is.Not.Null);
+      Random rnd = new Random();
+      var guid = Guid.NewGuid();
+      var record = new GuidTable { Id = rnd.Next(100), Uuid = guid };
+      context.Guidtable.Add(record);
+      context.SaveChanges();
+      var rows = context.Guidtable.Count();
+      Assert.That(rows, Is.EqualTo(1));
+      filter[0] = guid;
+      var resultFilter2 = context.Guidtable.Where(t => filter.Contains(t.Uuid)).ToArray();
+      Assert.That(resultFilter2.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestGuidContains()
+    {
+      MySQLTestStore.Execute("drop database if exists DbContextGuid; Create database DbContextGuid; ");
+      using var context = new ContextGUID();
+      context.Database.EnsureDeleted();
+      context.Database.EnsureCreated();
+      var guid1 = Guid.NewGuid();
+      var guid2 = Guid.NewGuid();
+      var guidTable1 = new GuidTable() { Id = 1, Uuid = guid1 };
+      var guidTable2 = new GuidTable() { Id = 2, Uuid = guid2 };
+      context.Guidtable.Add(guidTable1);
+      context.Guidtable.Add(guidTable2);
+      context.SaveChanges();
+      var filter = new[] { guid1 };
+      var resultFilter = context.Guidtable.Where(t => filter.Contains(t.Uuid)).ToArray();
+      Assert.That(resultFilter.Count(), Is.EqualTo(1));
+      Assert.That(resultFilter.First(), Is.EqualTo(guidTable1));
     }
 
     public class GuidTable

--- a/EFCore/tests/MySql.EFCore.Basic.Tests/EFCoreTests.cs
+++ b/EFCore/tests/MySql.EFCore.Basic.Tests/EFCoreTests.cs
@@ -292,5 +292,17 @@ namespace MySql.EntityFrameworkCore.Basic.Tests
         }
       }
     }
+    
+    [Test]
+    public void StringComparisonCheck()
+    {
+      using (SakilaLiteContext context = new SakilaLiteContext())
+      {
+        context.InitContext();
+                
+        var test = context.Customer.Where(x => x.LastName!.StartsWith("SMIT", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.That(test.Count, Is.GreaterThan(0));
+      }
+    }
   }
 }


### PR DESCRIPTION
When running a .Contains query with GUID types, we were running into an issue with efcore 10 unable to map the types, generating an InvalidOperationException 'Expression '@thingIds' in the SQL tree does not have a type mapping assigned.'

This error would be easy to generate, with the below code, where ThingId is a guid or a value object wrapper around a guid type.

var leases = await  DbContext.Things
				.Where(thing => thingIds.Contains(thing.ThingId))
				.ToArrayAsync(cancellationToken);

There's a fair few bugs around tracking this, such as https://bugs.mysql.com/bug.php?id=120483. The suggested fix there doesn't work however.

There's also an issue with some LIKE query translation, which I ran into and solved in a similar manner to this person
https://github.com/mysql/mysql-connector-net/pull/82

I'm not sure whether my solution is the best, but it works for efcore 10 in a .net 10 project. Some of the types are different in .net 9-8, so this fix only sorts behaviour for .net 10.