### PR TITLE
CommandTimeout and CancellationToken aren't honoured in the async path

### DIFF
--- a/MySQL.Data/src/CompressedStream.cs
+++ b/MySQL.Data/src/CompressedStream.cs
@@ -378,7 +378,7 @@ namespace MySql.Data.MySqlClient
       compressedBuffer.WriteByte(0x9c);
       var outCompStream = new DeflateStream(compressedBuffer, CompressionMode.Compress, true);
 
-      await outCompStream.WriteAsync(cacheBytes, 0, (int)cacheBytes.Length).ConfigureAwait(false);
+      await outCompStream.WriteAsync(cacheBytes, 0, (int)cache.Length).ConfigureAwait(false);
       outCompStream.Dispose();
       int adler = IPAddress.HostToNetworkOrder(Adler32(cacheBytes, 0, (int)cache.Length));
       await compressedBuffer.WriteAsync(BitConverter.GetBytes(adler), 0, sizeof(uint)).ConfigureAwait(false);

--- a/MySQL.Data/src/MySqlCommand.cs
+++ b/MySQL.Data/src/MySqlCommand.cs
@@ -873,6 +873,7 @@ namespace MySql.Data.MySqlClient
         MySqlDataReader reader = new MySqlDataReader(this, statement, behavior);
         connection.Reader = reader;
         Canceled = false;
+        using var cancellationRegistration = cancellationToken.Register(() => Cancel());
         // execute the statement
         statement.Execute();
         // wait for data to return
@@ -918,9 +919,14 @@ namespace MySql.Data.MySqlClient
             throw new MySqlException(ex.Message, true, ex);
           }
 
-          // if we caught an exception because of a cancel, then just return null
+          // if we caught an exception because of a cancel, propagate as OperationCanceledException
+          // when triggered by a cancellation token, otherwise return null (e.g. timeout-driven abort)
           if (mySqlException.IsQueryAborted)
+          {
+            if (cancellationToken.IsCancellationRequested)
+              throw new OperationCanceledException(cancellationToken);
             return null;
+          }
           if (mySqlException.IsFatal)
             Connection.Close();
           if (mySqlException.Number == 0)
@@ -1053,6 +1059,7 @@ namespace MySql.Data.MySqlClient
         MySqlDataReader reader = new MySqlDataReader(this, statement, behavior);
         connection.Reader = reader;
         Canceled = false;
+        using var cancellationRegistration = cancellationToken.Register(() => Cancel());
         // execute the statement
         await statement.ExecuteAsync().ConfigureAwait(false);
         // wait for data to return
@@ -1098,9 +1105,14 @@ namespace MySql.Data.MySqlClient
             throw new MySqlException(ex.Message, true, ex);
           }
 
-          // if we caught an exception because of a cancel, then just return null
+          // if we caught an exception because of a cancel, propagate as OperationCanceledException
+          // when triggered by a cancellation token, otherwise return null (e.g. timeout-driven abort)
           if (mySqlException.IsQueryAborted)
+          {
+            if (cancellationToken.IsCancellationRequested)
+              throw new OperationCanceledException(cancellationToken);
             return null;
+          }
           if (mySqlException.IsFatal)
             await Connection.CloseAsync().ConfigureAwait(false);
           if (mySqlException.Number == 0)

--- a/MySQL.Data/src/MySqlDataReader.cs
+++ b/MySQL.Data/src/MySqlDataReader.cs
@@ -242,6 +242,12 @@ namespace MySql.Data.MySqlClient
         // eat, on the same reason we eat IO exceptions wrapped into 
         // MySqlExceptions reasons, described above.
       }
+      catch (TimeoutException)
+      {
+        // eat, socket timeouts during sync IO are now surfaced as TimeoutException
+        // (converted in TimedStream.ReadAsync). Same reasoning as IOException above:
+        // we are closing the reader and do not want the exception to propagate.
+      }
       finally
       {
         // always ensure internal reader is null (Bug #55558)
@@ -319,6 +325,12 @@ namespace MySql.Data.MySqlClient
       {
         // eat, on the same reason we eat IO exceptions wrapped into 
         // MySqlExceptions reasons, described above.
+      }
+      catch (TimeoutException)
+      {
+        // eat, socket timeouts during async IO are now surfaced as TimeoutException
+        // (converted in TimedStream.ReadAsync). Same reasoning as IOException above:
+        // we are closing the reader and do not want the exception to propagate.
       }
       finally
       {

--- a/MySQL.Data/src/TimedStream.cs
+++ b/MySQL.Data/src/TimedStream.cs
@@ -29,6 +29,7 @@
 using MySql.Data.Common;
 using System;
 using System.IO;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -177,7 +178,7 @@ namespace MySql.Data.MySqlClient
       try
       {
         StartTimer(IOKind.Write);
-        await _baseStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+        await ExecuteAsyncWithTimeout(ct => _baseStream.FlushAsync(ct)).ConfigureAwait(false);
         StopTimer();
       }
       catch (Exception e)
@@ -221,6 +222,14 @@ namespace MySql.Data.MySqlClient
         StopTimer();
         return retval;
       }
+      catch (IOException e) when (e.GetBaseException() is SocketException { SocketErrorCode: SocketError.TimedOut })
+      {
+        // Sync path: socket read timeout manifests as IOException wrapping SocketException(TimedOut).
+        // Convert to TimeoutException so the caller routes it through HandleTimeoutOrThreadAbortAsync,
+        // which sends KILL QUERY to stop the query on the server.
+        HandleException(e);
+        throw new TimeoutException("Timeout in IO operation", e);
+      }
       catch (Exception e)
       {
         HandleException(e);
@@ -240,7 +249,7 @@ namespace MySql.Data.MySqlClient
       try
       {
         StartTimer(IOKind.Read);
-        int retval = await _baseStream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+        int retval = await ExecuteAsyncWithTimeout(ct => _baseStream.ReadAsync(buffer, offset, count, ct)).ConfigureAwait(false);
         StopTimer();
         return retval;
       }
@@ -314,7 +323,7 @@ namespace MySql.Data.MySqlClient
       try
       {
         StartTimer(IOKind.Write);
-        await _baseStream.WriteAsync(buffer, offset, count).ConfigureAwait(false);
+        await ExecuteAsyncWithTimeout(ct => _baseStream.WriteAsync(buffer, offset, count, ct)).ConfigureAwait(false);
         StopTimer();
       }
       catch (Exception e)
@@ -354,6 +363,51 @@ namespace MySql.Data.MySqlClient
       else
         _timeout = newTimeout;
       _stopwatch.Reset();
+    }
+
+    /// <summary>
+    /// Executes an async IO operation enforcing the remaining command timeout via a
+    /// <see cref="CancellationTokenSource"/>, because <see cref="Socket.ReceiveTimeout"/>
+    /// and <see cref="Socket.SendTimeout"/> are not honoured by async socket IO operations.
+    /// Callers are responsible for invoking <see cref="HandleException"/> on failure.
+    /// </summary>
+    private async Task<T> ExecuteAsyncWithTimeout<T>(Func<CancellationToken, Task<T>> operation)
+    {
+      if (_timeout == Timeout.Infinite)
+      {
+        return await operation(CancellationToken.None).ConfigureAwait(false);
+      }
+
+      int remainingMs = Math.Max(1, _timeout - (int)_stopwatch.ElapsedMilliseconds);
+      using var cts = new CancellationTokenSource(remainingMs);
+      try
+      {
+        return await operation(cts.Token).ConfigureAwait(false);
+      }
+      catch (OperationCanceledException e) when (cts.IsCancellationRequested)
+      {
+        throw new TimeoutException("Timeout in IO operation", e);
+      }
+    }
+
+    private async Task ExecuteAsyncWithTimeout(Func<CancellationToken, Task> operation)
+    {
+      if (_timeout == Timeout.Infinite)
+      {
+        await operation(CancellationToken.None).ConfigureAwait(false);
+        return;
+      }
+
+      int remainingMs = Math.Max(1, _timeout - (int)_stopwatch.ElapsedMilliseconds);
+      using var cts = new CancellationTokenSource(remainingMs);
+      try
+      {
+        await operation(cts.Token).ConfigureAwait(false);
+      }
+      catch (OperationCanceledException e) when (cts.IsCancellationRequested)
+      {
+        throw new TimeoutException("Timeout in IO operation", e);
+      }
     }
 
     /// <summary>

--- a/MySQL.Data/tests/MySql.Data.Tests/ConnectionTests.cs
+++ b/MySQL.Data/tests/MySql.Data.Tests/ConnectionTests.cs
@@ -111,8 +111,7 @@ namespace MySql.Data.MySqlClient.Tests
       for (var i = 0; i <= 11; i++)
       {
         var ex = Assert.Catch<MySqlException>(() => CreateCommandTimeoutException());
-        //Prior to the fix the exception thrown was 'error connecting: Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.' after the 10th execution.
-        Assert.That(ex.Message, Is.EqualTo("Fatal error encountered during command execution"));
+        Assert.That(ex.Message, Does.StartWith("Timeout expired."));
       }
     }
 

--- a/MySQL.Data/tests/MySql.Data.Tests/Framework/netstandard2_0/TimeoutAndCancel.cs
+++ b/MySQL.Data/tests/MySql.Data.Tests/Framework/netstandard2_0/TimeoutAndCancel.cs
@@ -30,6 +30,7 @@ using System;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Data;
 using System.Globalization;
 using System.IO;
@@ -42,9 +43,91 @@ namespace MySql.Data.MySqlClient.Tests
     private delegate void CommandInvokerDelegate(MySqlCommand cmdToRun);
     private ManualResetEvent resetEvent = new ManualResetEvent(false);
 
+    // Unique marker embedded in long-running test queries so parallel framework runs
+    // don't interfere with each other's PROCESSLIST polling.
+    private string m_testRunId = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+    // Connection string with pooling disabled so a killed connection is never returned
+    // to the pool and handed to a subsequent test's OpenAsync.
+    private string NoPoolConnectionString
+    {
+      get
+      {
+        MySqlConnectionStringBuilder b = new MySqlConnectionStringBuilder(Connection.ConnectionString);
+        b.Pooling = false;
+        return b.ConnectionString;
+      }
+    }
+
+    /// <summary>
+    /// Synchronous counterpart of <see cref="OpenTestConnectionAsync"/>.
+    /// </summary>
+    private MySqlConnection OpenTestConnectionWithRetry()
+    {
+      const int maxAttempts = 3;
+      for (int attempt = 1; attempt <= maxAttempts; attempt++)
+      {
+        MySqlConnection conn = new MySqlConnection(NoPoolConnectionString);
+        try
+        {
+          conn.Open();
+          return conn;
+        }
+        catch (MySqlException) when (attempt < maxAttempts)
+        {
+          conn.Dispose();
+          Thread.Sleep(300 * attempt);
+        }
+        catch
+        {
+          conn.Dispose();
+          throw;
+        }
+      }
+      throw new InvalidOperationException("OpenTestConnectionWithRetry: unreachable");
+    }
+
+    /// <summary>
+    /// Opens a no-pool test connection, retrying up to 3 times with a short delay.
+    /// Parallel framework assemblies may recycle MySQL server threads that still have
+    /// compressed-stream framing in flight; a brief pause lets the server finish cleanup.
+    /// </summary>
+    private async Task<MySqlConnection> OpenTestConnectionAsync()
+    {
+      const int maxAttempts = 3;
+      for (int attempt = 1; attempt <= maxAttempts; attempt++)
+      {
+        MySqlConnection conn = new MySqlConnection(NoPoolConnectionString);
+        try
+        {
+          await conn.OpenAsync();
+          return conn;
+        }
+        catch (MySqlException) when (attempt < maxAttempts)
+        {
+          conn.Dispose();
+          await Task.Delay(300 * attempt);
+        }
+        catch
+        {
+          conn.Dispose();
+          throw;
+        }
+      }
+      // Unreachable, but satisfies the compiler.
+      throw new InvalidOperationException("OpenTestConnectionAsync: unreachable");
+    }
+
     protected override void Cleanup()
     {
       ExecuteSQL(String.Format("DROP TABLE IF EXISTS `{0}`.Test", Connection.Database));
+    }
+
+    [SetUp]
+    public void RegenerateTestRunId()
+    {
+      // Fresh ID per test so PROCESSLIST polling is isolated from parallel framework runs.
+      m_testRunId = Guid.NewGuid().ToString("N").Substring(0, 8);
     }
 
     private void CommandRunner(MySqlCommand cmdToRun)
@@ -341,5 +424,274 @@ namespace MySql.Data.MySqlClient.Tests
         Assert.That(i, Is.EqualTo(rows));
       }
     }
-  }
+
+    private const string ProcessListQuery =
+      "SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE INFO LIKE '{0}' AND INFO NOT LIKE '%PROCESSLIST%'";
+
+    /// <summary>
+    /// Polls PROCESSLIST until the query count satisfies <paramref name="expectedCount"/> or
+    /// <paramref name="maxWaitMs"/> elapses. Returns true when the condition is met.
+    /// </summary>
+    private async Task<bool> WaitForProcessListAsync(string likePattern, long expectedCount, int maxWaitMs = 5000)
+    {
+      string sql = string.Format(ProcessListQuery, likePattern);
+      int elapsed = 0;
+      const int intervalMs = 150;
+      while (elapsed < maxWaitMs)
+      {
+        using MySqlCommand cmd = new MySqlCommand(sql, Root);
+        long count = Convert.ToInt64(await cmd.ExecuteScalarAsync() ?? 0L);
+        if (count == expectedCount) { return true; }
+        await Task.Delay(intervalMs);
+        elapsed += intervalMs;
+      }
+      return false;
+    }
+
+    /// <summary>
+    /// Synchronous counterpart of <see cref="WaitForProcessListAsync"/>.
+    /// </summary>
+    private bool WaitForProcessList(string likePattern, long expectedCount, int maxWaitMs = 5000)
+    {
+      string sql = string.Format(ProcessListQuery, likePattern);
+      int elapsed = 0;
+      const int intervalMs = 150;
+      while (elapsed < maxWaitMs)
+      {
+        using MySqlCommand cmd = new MySqlCommand(sql, Root);
+        long count = Convert.ToInt64(cmd.ExecuteScalar() ?? 0L);
+        if (count == expectedCount) { return true; }
+        Thread.Sleep(intervalMs);
+        elapsed += intervalMs;
+      }
+      return false;
+    }
+
+    /// <summary>
+    /// Verifies that cancelling a CancellationToken causes the running query to be
+    /// killed server-side via KILL QUERY so it no longer appears in PROCESSLIST.
+    /// Fix: cancellationToken.Register(() => Cancel()) wired inside ExecuteReaderAsync.
+    /// </summary>
+    [Test]
+    public async Task CancellationToken_QueryKilledOnServer()
+    {
+        MySqlConnection testConn = await OpenTestConnectionAsync();
+        Exception caughtException = null;
+        Task queryTask = Task.CompletedTask;
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            MySqlCommand cmd = new MySqlCommand($"SELECT SLEEP(60) /* testrun:{m_testRunId} */", testConn);
+
+            queryTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await cmd.ExecuteNonQueryAsync(cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    caughtException = ex;
+                }
+            });
+
+            // Wait until the SLEEP shows up in PROCESSLIST before cancelling.
+            bool appeared = await WaitForProcessListAsync($"%testrun:{m_testRunId}%", expectedCount: 1);
+            Assert.That(appeared, Is.True, "Query never appeared in PROCESSLIST.");
+
+            // Cancel the token — this sends KILL QUERY via a separate connection.
+            // Note: SELECT SLEEP(N) returns 1 when interrupted, not error 1317, so the task
+            // may complete without throwing. Without the fix, Cancel() is never wired so the
+            // server query keeps running and the task never completes — deadline guards against that.
+            cts.Cancel();
+            bool completed = await Task.WhenAny(queryTask, Task.Delay(10000)) == queryTask;
+
+            // Only close after the task has finished (or timed out); closing while a TLS async
+            // read is in flight causes NotSupportedException on SSL streams.
+            testConn.Close();
+            await queryTask;
+
+            Assert.That(completed, Is.True,
+                "ExecuteNonQueryAsync did not return after cancellation — KILL QUERY was likely not sent to the server.");
+
+            Assert.That(caughtException, Is.Not.InstanceOf<NullReferenceException>(),
+                "NullReferenceException indicates the query abort was not handled correctly.");
+
+            bool gone = await WaitForProcessListAsync($"%testrun:{m_testRunId}%", expectedCount: 0);
+            Assert.That(gone, Is.True, "Query was not killed on the server after cancellation.");
+        }
+        finally
+        {
+            // Ensure the connection is closed and the task has completed before we return,
+            // so no background IO races with the next test's connection open.
+            if (testConn.State != System.Data.ConnectionState.Closed) { testConn.Close(); }
+            await queryTask;
+            testConn.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that cancelling a CancellationToken throws OperationCanceledException
+    /// and not a NullReferenceException.
+    /// Fix: IsQueryAborted + cancellationToken.IsCancellationRequested now throws OperationCanceledException.
+    /// </summary>
+    [Test]
+    public async Task CancellationToken_ThrowsOperationCanceledException()
+    {
+        MySqlConnection testConn = await OpenTestConnectionAsync();
+        Exception caughtException = null;
+        Task queryTask = Task.CompletedTask;
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            MySqlCommand cmd = new MySqlCommand($"SELECT SLEEP(60) /* testrun:{m_testRunId} */", testConn);
+
+            queryTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await cmd.ExecuteNonQueryAsync(cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    caughtException = ex;
+                }
+            });
+
+            // Wait until the query appears in PROCESSLIST before cancelling.
+            bool appeared = await WaitForProcessListAsync($"%testrun:{m_testRunId}%", expectedCount: 1);
+            Assert.That(appeared, Is.True, "Query never appeared in PROCESSLIST.");
+            cts.Cancel();
+
+            // Await the task before closing: closing while a TLS async read is in flight
+            // causes NotSupportedException on SSL streams.
+            bool completed = await Task.WhenAny(queryTask, Task.Delay(10000)) == queryTask;
+            testConn.Close();
+            await queryTask;
+
+            Assert.That(completed, Is.True,
+                "ExecuteNonQueryAsync did not return after cancellation — KILL QUERY was likely not sent to the server.");
+
+            bool gone = await WaitForProcessListAsync($"%testrun:{m_testRunId}%", expectedCount: 0);
+            Assert.That(gone, Is.True, "Query was not killed on the server after cancellation.");
+
+            // SELECT SLEEP(N) returns 1 (interrupted) when KILL QUERY is sent — MySQL does not raise
+            // error 1317 for SLEEP(), so ExecuteNonQueryAsync may complete without throwing at all.
+            // The actual bug was: when error 1317 *was* raised, the connector returned null, causing a
+            // NullReferenceException downstream. Verify that whatever happened, it was not that.
+            Assert.That(caughtException, Is.Not.InstanceOf<NullReferenceException>(),
+                "Got NullReferenceException which indicates the query abort was not handled correctly.");
+
+            // If an exception was thrown, it must be OperationCanceledException or MySqlException(1317)
+            if (caughtException != null)
+            {
+                bool isValidException = caughtException is OperationCanceledException ||
+                                        (caughtException is MySqlException mex && mex.Number == (int)MySqlErrorCode.QueryInterrupted);
+                Assert.That(isValidException, Is.True,
+                    $"Expected OperationCanceledException or MySqlException(1317) but got {caughtException.GetType().Name}: {caughtException.Message}");
+            }
+        }
+        finally
+        {
+            if (testConn.State != System.Data.ConnectionState.Closed) { testConn.Close(); }
+            await queryTask;
+            testConn.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a synchronous CommandTimeout kills the query server-side so it no
+    /// longer appears in PROCESSLIST after the timeout fires.
+    /// Fix: TimedStream sync IOException(SocketException:TimedOut) path already worked;
+    /// this test confirms the full end-to-end kill flow for sync execution.
+    /// </summary>
+    [Test]
+    public void SyncCommandTimeout_QueryKilledOnServer()
+    {
+        MySqlConnection testConn = OpenTestConnectionWithRetry();
+        using var _ = testConn;
+
+        // Verify the query appears in PROCESSLIST then disappears within the timeout window.
+        // Note: SELECT SLEEP(N) returns 1 (interrupted) when KILL QUERY is sent — MySQL does not
+        // raise error 1317 for SLEEP(), so ExecuteNonQuery may complete without throwing.
+        MySqlCommand cmd = new MySqlCommand($"SELECT SLEEP(60) /* testrun:{m_testRunId} */", testConn);
+        cmd.CommandTimeout = 2;
+
+        Exception caughtException = null;
+        try
+        {
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            caughtException = ex;
+        }
+
+        // If an exception was thrown it must not be a NullReferenceException
+        Assert.That(caughtException, Is.Not.InstanceOf<NullReferenceException>(),
+            "NullReferenceException indicates the query abort was not handled correctly.");
+
+        // Poll until the server confirms the query is gone (up to 5 s).
+        bool gone = WaitForProcessList($"%testrun:{m_testRunId}%", expectedCount: 0);
+        Assert.That(gone, Is.True, "Query was not killed on the server after sync timeout.");
+    }
+
+    /// <summary>
+    /// Verifies that an async CommandTimeout kills the query server-side so it no
+    /// longer appears in PROCESSLIST after the timeout fires.
+    /// Fix: TimedStream.ExecuteAsyncWithTimeout enforces timeout on IOCP async reads
+    /// (NetworkStream.ReadAsync ignores Socket.ReceiveTimeout).
+    /// </summary>
+    [Test]
+    public async Task AsyncCommandTimeout_QueryKilledOnServer()
+    {
+        MySqlConnection testConn = await OpenTestConnectionAsync();
+        Exception caughtException = null;
+        Task executeTask = Task.CompletedTask;
+        try
+        {
+            // Note: SELECT SLEEP(N) returns 1 (interrupted) when KILL QUERY is sent — MySQL does not
+            // raise error 1317 for SLEEP(), so ExecuteNonQueryAsync may complete without throwing.
+            MySqlCommand cmd = new MySqlCommand($"SELECT SLEEP(60) /* testrun:{m_testRunId} */", testConn);
+            cmd.CommandTimeout = 2;
+
+            // Without the fix, async reads ignore Socket.ReceiveTimeout so this hangs indefinitely.
+            // Use a deadline of CommandTimeout + 10 s to fail clearly rather than hanging the test run.
+            int deadlineMs = (cmd.CommandTimeout + 10) * 1000;
+            executeTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await cmd.ExecuteNonQueryAsync(CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    caughtException = ex;
+                }
+            });
+
+            // Await the task with a deadline before closing: closing while a TLS async read is
+            // in flight causes NotSupportedException on SSL streams. Without the fix, async reads
+            // ignore Socket.ReceiveTimeout so the task would hang past the deadline.
+            bool completed = await Task.WhenAny(executeTask, Task.Delay(deadlineMs)) == executeTask;
+            testConn.Close();
+            await executeTask;
+
+            Assert.That(completed, Is.True,
+                "ExecuteNonQueryAsync did not return after CommandTimeout elapsed — async timeout is not enforced.");
+
+            Assert.That(caughtException, Is.Not.InstanceOf<NullReferenceException>(),
+                "NullReferenceException indicates the query abort was not handled correctly.");
+
+            bool gone = await WaitForProcessListAsync($"%testrun:{m_testRunId}%", expectedCount: 0);
+            Assert.That(gone, Is.True, "Query was not killed on the server after async timeout.");
+        }
+        finally
+        {
+            if (testConn.State != System.Data.ConnectionState.Closed) { testConn.Close(); }
+            await executeTask;
+            testConn.Dispose();
+        }
+    }
+}
 }


### PR DESCRIPTION
Below issues were observed when working with async command execution:

1) CommandTimeout  wasn't honoured by async socket IO operations, so command timeouts were silently ignored on the async path. This was causing a running query to continue executing even when timeout was reached.
=> Fix: Enforce command timeout for async socket IO in TimedStream

2) CancellationToken wasn't honoured and wasn't being forwarded to the server. This was causing a running query to continue executing even when CancellationToken was cancelled.
=> Fix: Propagate external CancellationToken to in-flight queries in MySqlCommand

3) CompressCacheAsync used cacheBytes.Length (the internal MemoryStream buffer capacity returned by GetBuffer(), which includes unwritten trailing bytes) instead of cache.Length (the actual number of logically written bytes). This caused garbage bytes  beyond the logical data to be included in the compressed packet, producing malformed output that caused the server to close the  connection.
=> Fixed to use (int)cache.Length, matching the sync CompressCache path.
