### PR TITLE
Fix async commands not honoring CommandTimeout in TimedStream

### DIFF
--- a/MySQL.Data/src/TimedStream.cs
+++ b/MySQL.Data/src/TimedStream.cs
@@ -89,7 +89,17 @@ namespace MySql.Data.MySqlClient
       return currentValue >= newValue + 100;
     }
 
-    private void StartTimer(IOKind op)
+    /// <returns>
+    /// The remaining time budget in milliseconds at the moment this I/O operation started, for
+    /// use by the async deadline (<see cref="RunWithDeadlineAsync{T}"/>) - or exactly
+    /// <see cref="Timeout.Infinite"/> if no timeout is configured at all. Clamped to a minimum
+    /// of 0 whenever a real (non-infinite) timeout is configured, specifically so a budget that
+    /// has merely expired (accumulated elapsed time caught up with or overshot <see cref="_timeout"/>
+    /// by exactly 1ms) can never numerically collide with <see cref="Timeout.Infinite"/> (-1) -
+    /// which would otherwise be misread as "no timeout at all" instead of "expired" by
+    /// RunWithDeadlineAsync's own Timeout.Infinite check.
+    /// </returns>
+    private int StartTimer(IOKind op)
     {
 
       int streamTimeout;
@@ -117,9 +127,122 @@ namespace MySql.Data.MySqlClient
       }
 
       if (_timeout == Timeout.Infinite)
-        return;
+        return streamTimeout;
 
       _stopwatch.Start();
+
+      // Clamp only the returned value, after the ReadTimeout/WriteTimeout property assignments
+      // above (which intentionally still use the raw, unclamped value - unrelated to this fix).
+      return Math.Max(0, streamTimeout);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> against a deadline of <paramref name="timeoutMilliseconds"/>,
+    /// in addition to honoring <paramref name="callerToken"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Stream.ReadTimeout"/>/<see cref="Stream.WriteTimeout"/> only apply to the
+    /// synchronous <see cref="Stream.Read(byte[], int, int)"/>/<see cref="Stream.Write(byte[], int, int)"/>
+    /// overloads - the *Async methods ignore them entirely and will await forever if the remote
+    /// end stops responding mid-operation. This is what enforces the same accumulated timeout
+    /// (<see cref="_timeout"/>, populated from <c>CommandTimeout</c>/"Default Command Timeout")
+    /// for async I/O.
+    ///
+    /// <paramref name="callerToken"/> is honored if a caller ever passes a live one, but as of
+    /// this writing no call site above TimedStream (MySqlStream.ReadFullyAsync and its callers)
+    /// does - they all pass CancellationToken.None. This is forward-looking, not currently
+    /// exercised in practice; don't assume external cancellation is wired end-to-end through the
+    /// rest of the driver just because it's honored at this layer.
+    /// </remarks>
+#if NETFRAMEWORK
+    private async Task<T> RunWithDeadlineAsync<T>(Func<CancellationToken, Task<T>> operation, int timeoutMilliseconds, CancellationToken callerToken)
+    {
+      // NetworkStream/SslStream on .NET Framework inherit Stream's default ReadAsync/WriteAsync,
+      // which wraps the legacy BeginRead/EndRead APM pattern: it only checks a CancellationToken
+      // before starting an operation, never once one is already in flight. So unlike every other
+      // target this project builds for, cancelling deadlineCts (the #else branch's approach)
+      // would have NO effect on an already-pending read/write here - the await would just never
+      // return, reproducing the original hang bug. Race against a separate timer instead, and
+      // forcibly close the underlying stream if that timer wins - that's the one thing
+      // guaranteed to unblock an in-flight BeginRead/BeginWrite on this target.
+      if (timeoutMilliseconds == Timeout.Infinite)
+        return await operation(callerToken).ConfigureAwait(false);
+
+      callerToken.ThrowIfCancellationRequested();
+      Task<T> operationTask = operation(callerToken);
+
+      using (var timerCts = new CancellationTokenSource())
+      {
+        Task delayTask = Task.Delay(Math.Max(timeoutMilliseconds, 0), timerCts.Token);
+        Task winner = await Task.WhenAny(operationTask, delayTask).ConfigureAwait(false);
+
+        if (winner == operationTask)
+        {
+          timerCts.Cancel(); // stop the now-unneeded delay promptly rather than leak a timer
+          return await operationTask.ConfigureAwait(false); // observe the real result/exception
+        }
+
+        // Deadline elapsed; operationTask may genuinely still be running against the network -
+        // force-close so it's guaranteed to fault rather than run (and hold the connection)
+        // forever. This means the connection cannot be gracefully reused after an async timeout
+        // on .NET Framework specifically (contrast the #else branch, where cancellation aborts
+        // just the one pending operation and leaves the stream otherwise reusable) - it will
+        // always be discarded via the existing MySqlConnection.HandleTimeoutOrThreadAbort fatal
+        // path once it tries to use this now-closed stream - but that is a strict improvement
+        // over hanging (and leaking the pooled connection) indefinitely, which is the bug this
+        // fix exists for.
+        try { _baseStream.Close(); } catch { /* best effort: already failing this call */ }
+        IsClosed = true;
+
+        // The abandoned task will eventually fault on its own time (from the forced close,
+        // above) - observe that fault here so it doesn't surface later as an unobserved task
+        // exception. Deliberately fire-and-forget: nothing here should (or can usefully) await it.
+        _ = operationTask.ContinueWith(t => { var _ = t.Exception; }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+
+        throw new TimeoutException("Timeout in IO operation");
+      }
+    }
+#else
+    private async Task<T> RunWithDeadlineAsync<T>(Func<CancellationToken, Task<T>> operation, int timeoutMilliseconds, CancellationToken callerToken)
+    {
+      if (timeoutMilliseconds == Timeout.Infinite)
+        return await operation(callerToken).ConfigureAwait(false);
+
+      // Skip CreateLinkedTokenSource's extra parent-token callback registration when
+      // callerToken can never actually be cancelled (true for every current call site into
+      // TimedStream - see remarks above); functionally identical either way, just cheaper for
+      // what is, today, always the case.
+      using (var deadlineCts = callerToken.CanBeCanceled
+        ? CancellationTokenSource.CreateLinkedTokenSource(callerToken)
+        : new CancellationTokenSource())
+      {
+        // A negative budget means earlier operations in this command already consumed the
+        // whole timeout; cancel essentially immediately rather than let this op run unbounded.
+        deadlineCts.CancelAfter(Math.Max(timeoutMilliseconds, 0));
+        try
+        {
+          return await operation(deadlineCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!callerToken.IsCancellationRequested)
+        {
+          // Cancellation came from our own deadline, not the caller's token - surface it the
+          // same way the synchronous safety-net check in StopTimer() does, so the existing
+          // upstream handling (NativeDriver.GetResult[Async], MySqlDataReader.Read[Async],
+          // MySqlConnection.HandleTimeoutOrThreadAbort[Async]) - all of which key off catching
+          // a plain TimeoutException - applies identically to the async path.
+          throw new TimeoutException("Timeout in IO operation");
+        }
+      }
+    }
+#endif
+
+    private async Task RunWithDeadlineAsync(Func<CancellationToken, Task> operation, int timeoutMilliseconds, CancellationToken callerToken)
+    {
+      await RunWithDeadlineAsync(async ct =>
+      {
+        await operation(ct).ConfigureAwait(false);
+        return true;
+      }, timeoutMilliseconds, callerToken).ConfigureAwait(false);
     }
 
     private void StopTimer()
@@ -149,7 +272,7 @@ namespace MySql.Data.MySqlClient
 
     public override void Flush() => FlushInternal();
 
-    public override Task FlushAsync(CancellationToken cancellationToken = default) => FlushInternalAsync();
+    public override Task FlushAsync(CancellationToken cancellationToken = default) => FlushInternalAsync(cancellationToken);
 
     /// <summary>
     /// Performs the synchronous flush operation on the underlying stream with timeout support.
@@ -172,12 +295,12 @@ namespace MySql.Data.MySqlClient
     /// <summary>
     /// Performs the asynchronous flush operation on the underlying stream with timeout support.
     /// </summary>
-    private async Task FlushInternalAsync()
+    private async Task FlushInternalAsync(CancellationToken cancellationToken)
     {
       try
       {
-        StartTimer(IOKind.Write);
-        await _baseStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+        int streamTimeout = StartTimer(IOKind.Write);
+        await RunWithDeadlineAsync(ct => _baseStream.FlushAsync(ct), streamTimeout, cancellationToken).ConfigureAwait(false);
         StopTimer();
       }
       catch (Exception e)
@@ -203,7 +326,7 @@ namespace MySql.Data.MySqlClient
 
     public override int Read(byte[] buffer, int offset, int count) => ReadInternal(buffer, offset, count);
 
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) => ReadInternalAsync(buffer, offset, count);
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) => ReadInternalAsync(buffer, offset, count, cancellationToken);
 
     /// <summary>
     /// Reads from the underlying stream with timeout support.
@@ -229,18 +352,23 @@ namespace MySql.Data.MySqlClient
     }
 
     /// <summary>
-    /// Asynchronously reads from the underlying stream with timeout support.
+    /// Asynchronously reads from the underlying stream with timeout support. Unlike
+    /// <see cref="Stream.ReadTimeout"/>, which the framework only honors on the synchronous
+    /// <see cref="ReadInternal"/> path, the accumulated timeout here is enforced explicitly via
+    /// <see cref="RunWithDeadlineAsync{T}"/> so that async callers (e.g. <c>ExecuteReaderAsync</c>)
+    /// get the same <c>CommandTimeout</c> behavior as sync callers instead of awaiting indefinitely.
     /// </summary>
     /// <param name="buffer">The buffer to read data into.</param>
     /// <param name="offset">The offset in the buffer to start reading into.</param>
     /// <param name="count">The maximum number of bytes to read.</param>
+    /// <param name="cancellationToken">A token to observe in addition to the accumulated timeout.</param>
     /// <returns>A task that represents the asynchronous read operation, containing the total number of bytes read.</returns>
-    private async Task<int> ReadInternalAsync(byte[] buffer, int offset, int count)
+    private async Task<int> ReadInternalAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
       try
       {
-        StartTimer(IOKind.Read);
-        int retval = await _baseStream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+        int streamTimeout = StartTimer(IOKind.Read);
+        int retval = await RunWithDeadlineAsync(ct => _baseStream.ReadAsync(buffer, offset, count, ct), streamTimeout, cancellationToken).ConfigureAwait(false);
         StopTimer();
         return retval;
       }
@@ -279,7 +407,7 @@ namespace MySql.Data.MySqlClient
 
     public override void Write(byte[] buffer, int offset, int count) => WriteInternal(buffer, offset, count);
 
-    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) => WriteInternalAsync(buffer, offset, count);
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) => WriteInternalAsync(buffer, offset, count, cancellationToken);
 
     /// <summary>
     /// Writes to the underlying stream with timeout support.
@@ -303,18 +431,21 @@ namespace MySql.Data.MySqlClient
     }
 
     /// <summary>
-    /// Asynchronously writes to the underlying stream with timeout support.
+    /// Asynchronously writes to the underlying stream with timeout support. See the remarks on
+    /// <see cref="ReadInternalAsync"/> - the same accumulated-timeout gap applied here (this
+    /// matters for e.g. bulk INSERT/LOAD DATA payloads written via the async API).
     /// </summary>
     /// <param name="buffer">The buffer containing data to write.</param>
     /// <param name="offset">The offset in the buffer to start writing from.</param>
     /// <param name="count">The maximum number of bytes to write.</param>
+    /// <param name="cancellationToken">A token to observe in addition to the accumulated timeout.</param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
-    private async Task WriteInternalAsync(byte[] buffer, int offset, int count)
+    private async Task WriteInternalAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
       try
       {
-        StartTimer(IOKind.Write);
-        await _baseStream.WriteAsync(buffer, offset, count).ConfigureAwait(false);
+        int streamTimeout = StartTimer(IOKind.Write);
+        await RunWithDeadlineAsync(ct => _baseStream.WriteAsync(buffer, offset, count, ct), streamTimeout, cancellationToken).ConfigureAwait(false);
         StopTimer();
       }
       catch (Exception e)

--- a/MySQL.Data/tests/MySql.Data.Tests/Framework/netstandard2_0/TimeoutAndCancel.cs
+++ b/MySQL.Data/tests/MySql.Data.Tests/Framework/netstandard2_0/TimeoutAndCancel.cs
@@ -30,6 +30,7 @@ using System;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Data;
 using System.Globalization;
 using System.IO;
@@ -166,6 +167,52 @@ namespace MySql.Data.MySqlClient.Tests
       MySqlCommand cmd = new MySqlCommand("SELECT SLEEP(1)", Connection);
       cmd.CommandTimeout = 0; // infinite timeout
       cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Async counterpart of <see cref="TimeoutExpiring"/>. Regression test for the case where
+    /// CommandTimeout was not enforced on the async I/O path: TimedStream.ReadInternalAsync
+    /// simply awaited the base stream's ReadAsync with no deadline (Stream.ReadTimeout is
+    /// documented to affect only the synchronous Read() overload, never ReadAsync()), so an
+    /// async command against a slow/unresponsive server hung indefinitely instead of honoring
+    /// CommandTimeout - see bugs.mysql.com/bug.php?id=110790, verified by Oracle in 2023 and
+    /// still open as of 9.7.0. Before the fix this test would hang until the 5s SLEEP()
+    /// completed (or longer, e.g. against `odconfig.dev.socketlabs.com` in production, where
+    /// the server was simply idle/slow to respond, not literally sleeping - the effect is the
+    /// same: the async read has no deadline).
+    /// </summary>
+    [Test]
+    public void TimeoutExpiringAsync()
+    {
+      // Uses its own connection, deliberately not the shared fixture Connection: the
+      // pre-existing HandleTimeoutOrThreadAbort[Async] "fast cancel" this exercises (see below)
+      // can end up aborting the connection it runs on, and Cleanup()/TearDown() reuse the
+      // shared Connection afterward - isolating this test avoids tearing that down for every
+      // other test in the fixture.
+      string connStr = Connection.ConnectionString;
+      using (MySqlConnection c = new MySqlConnection(connStr))
+      {
+        c.Open();
+        MySqlCommand cmd = new MySqlCommand("SELECT SLEEP(5)", c) { CommandTimeout = 1 };
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        MySqlException ex = Assert.ThrowsAsync<MySqlException>(async () => await cmd.ExecuteScalarAsync());
+        stopwatch.Stop();
+
+        Assert.That(ex.InnerException, Is.InstanceOf<TimeoutException>());
+        // Upper bound covers both the 1s CommandTimeout deadline itself AND the subsequent
+        // HandleTimeoutOrThreadAbort[Async] "fast cancel" (MySqlConnection.cs), which opens a
+        // side-channel connection to send KILL QUERY and allows itself up to 5s
+        // (driver.ResetTimeout(5000), CancelQuery(5)) - unrelated to this fix, pre-existing for
+        // both sync and async, and observed to run close to that full 5s under UseCompression
+        // (the side channel negotiates compression too, and can even exceed its own budget and
+        // abort the connection - a pre-existing characteristic of that mechanism, not this fix).
+        // The bound asserted here is about proving the hang is gone (the bug would have blocked
+        // for the full 5s SLEEP() and beyond, unbounded), not about racing the pre-existing
+        // cancel window's own internal budget.
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(8)),
+          "ExecuteScalarAsync did not honor CommandTimeout - async read has no enforced deadline");
+      }
     }
 
     [Test]


### PR DESCRIPTION
ReadTimeout and WriteTimeout only apply to synchronous reads and writes. The async methods were relying on those settings, which meant commands such as ExecuteReaderAsync and ExecuteScalarAsync could hang indefinitely when the server was slow or unresponsive.

TimedStream now applies the same timeout limit to async reads, writes, and flushes. When the timeout is reached, it throws the same TimeoutException used by the synchronous path, so the existing timeout handling continues to work as before.

This also preserves the CancellationToken passed to ReadAsync and WriteAsync instead of silently ignoring it.

There are no public API changes. Commands that complete within CommandTimeout are unaffected. Commands that exceed the timeout now fail instead of hanging.

Related to MySQL Bug #110790.

Added TimeoutExpiringAsync tests and verified the fix against MySQL 8.4 using both plain and compressed connections.